### PR TITLE
feat(query): add JSON output format with --json flag

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,6 +51,9 @@ var (
 
 	// Deep research options.
 	reasoningEffort string
+
+	// Output options.
+	outputJSON bool
 )
 
 // rootCmd represents the base command when called without any subcommands.
@@ -131,6 +134,10 @@ func addResearchFlags(cmd *cobra.Command) {
 		"Reasoning effort for sonar-deep-research: low, medium, or high")
 }
 
+func addOutputFlags(cmd *cobra.Command) {
+	cmd.PersistentFlags().BoolVar(&outputJSON, "json", outputJSON, "Output response in JSON format")
+}
+
 func init() {
 	rootCmd.AddCommand(chatCmd)
 	addChatFlags(chatCmd)
@@ -151,6 +158,7 @@ func init() {
 	addFormatFlags(queryCmd)
 	addDateFlags(queryCmd)
 	addResearchFlags(queryCmd)
+	addOutputFlags(queryCmd)
 
 	rootCmd.AddCommand(mcpStdioCmd)
 }


### PR DESCRIPTION
feat(query): add JSON output format with --json flag

Add --json flag to query command for machine-readable output.
Refactor rendering logic into console package for better code
organization and reusability.

- Add RenderJSON() and RenderResponse() to console package
- Add --json flag to query command
- Simplify query.go by eliminating nested conditionals
- Support JSON output for both streaming and non-streaming modes
- Include content, model, usage, search results, images, and
  related questions in JSON response
