### PR TITLE
feat(cli): add short flag aliases for frequently used options

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,11 +84,11 @@ pplx query -p "Latest AI news" --model "llama-3.1-sonar-large-128k-online"
 #### Advanced Search Options
 
 ```sh
-# Search only from specific domains
-pplx query -p "climate change research" --search-domains nature.com,science.org
+# Search only from specific domains (using short flag)
+pplx query -p "climate change research" -d nature.com,science.org
 
-# Get recent information only (last week)
-pplx query -p "stock market updates" --search-recency week
+# Get recent information only (last week) - using short flag
+pplx query -p "stock market updates" -r week
 
 # Location-based query
 pplx query -p "weather forecast" --location-lat 48.8566 --location-lon 2.3522 --location-country FR
@@ -97,24 +97,24 @@ pplx query -p "weather forecast" --location-lat 48.8566 --location-lon 2.3522 --
 #### Response Enhancement
 
 ```sh
-# Include images in the response
-pplx query -p "Famous landmarks in Paris" --return-images
+# Include images in the response (using short flag)
+pplx query -p "Famous landmarks in Paris" -i
 
-# Get related questions
-pplx query -p "How to learn programming" --return-related
+# Get related questions (using short flag)
+pplx query -p "How to learn programming" -q
 
 # Filter images by format and domain
-pplx query -p "Nature photography" --return-images --image-formats jpg,png --image-domains unsplash.com,pexels.com
+pplx query -p "Nature photography" -i --image-formats jpg,png --image-domains unsplash.com,pexels.com
 ```
 
 #### Generation Parameters
 
 ```sh
-# Control response length
-pplx query -p "Summarize War and Peace" --max-tokens 500
+# Control response length (using short flag)
+pplx query -p "Summarize War and Peace" -T 500
 
-# Fine-tune creativity and randomness
-pplx query -p "Write a haiku about coding" --temperature 0.8 --top-p 0.95
+# Fine-tune creativity and randomness (using short flags)
+pplx query -p "Write a haiku about coding" -t 0.8 --top-p 0.95
 
 # Adjust frequency and presence penalties
 pplx query -p "Explain machine learning concepts" --frequency-penalty 0.5 --presence-penalty 0.3
@@ -123,27 +123,27 @@ pplx query -p "Explain machine learning concepts" --frequency-penalty 0.5 --pres
 #### Combined Examples
 
 ```sh
-# Technical research with specific sources and recent data
+# Technical research with specific sources and recent data (using short flags)
 pplx query -p "Latest developments in quantum computing" \
-  --search-domains arxiv.org,nature.com \
-  --search-recency month \
-  --return-related \
-  --max-tokens 1000
+  -d arxiv.org,nature.com \
+  -r month \
+  -q \
+  -T 1000
 
-# Local business search with images
+# Local business search with images (using short flags)
 pplx query -p "Best restaurants near me" \
   --location-lat 40.7128 \
   --location-lon -74.0060 \
   --location-country US \
-  --return-images \
-  --search-recency week
+  -i \
+  -r week
 
-# Creative writing with custom parameters
+# Creative writing with custom parameters (using short flags)
 pplx query -p "Write a short story about AI" \
   -s "You are a creative science fiction writer" \
-  --temperature 0.9 \
-  --top-k 50 \
-  --max-tokens 2000
+  -t 0.9 \
+  -k 50 \
+  -T 2000
 ```
 
 ## Available Options
@@ -154,20 +154,22 @@ pplx query -p "Write a short story about AI" \
 |--------|-------|------|-------------|
 | `--model` | `-m` | string | AI model to use |
 | `--frequency-penalty` | | float64 | Penalize frequent tokens (0.0-2.0) |
-| `--max-tokens` | | int | Maximum tokens in response |
+| `--max-tokens` | `-T` | int | Maximum tokens in response |
 | `--presence-penalty` | | float64 | Penalize already present tokens (0.0-2.0) |
-| `--temperature` | | float64 | Response randomness (0.0-2.0) |
-| `--top-k` | | int | Consider only top K tokens |
+| `--temperature` | `-t` | float64 | Response randomness (0.0-2.0) |
+| `--top-k` | `-k` | int | Consider only top K tokens |
 | `--top-p` | | float64 | Nucleus sampling threshold |
 | `--timeout` | | duration | HTTP request timeout |
-| `--search-domains` | | []string | Filter search to specific domains |
-| `--search-recency` | | string | Filter by time: day, week, month, year |
+| `--search-domains` | `-d` | []string | Filter search to specific domains |
+| `--search-recency` | `-r` | string | Filter by time: day, week, month, year |
+| `--search-mode` | `-a` | string | Search mode: web (default) or academic |
+| `--search-context-size` | `-c` | string | Search context size: low, medium, or high |
 | `--location-lat` | | float64 | User location latitude |
 | `--location-lon` | | float64 | User location longitude |
 | `--location-country` | | string | User location country code |
-| `--return-images` | | bool | Include images in response |
-| `--return-related` | | bool | Include related questions |
-| `--stream` | | bool | Enable streaming responses |
+| `--return-images` | `-i` | bool | Include images in response |
+| `--return-related` | `-q` | bool | Include related questions |
+| `--stream` | `-S` | bool | Enable streaming responses |
 | `--image-domains` | | []string | Filter images by domains |
 | `--image-formats` | | []string | Filter images by formats |
 

--- a/cmd/flags_test.go
+++ b/cmd/flags_test.go
@@ -1,0 +1,148 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// TestShortFlagAliases tests that all short flag aliases are properly defined
+func TestShortFlagAliases(t *testing.T) {
+	tests := []struct {
+		name      string
+		shortFlag string
+		longFlag  string
+		setupCmd  func(*cobra.Command)
+	}{
+		// Search flags
+		{"search-domains", "d", "search-domains", addSearchFlags},
+		{"search-recency", "r", "search-recency", addSearchFlags},
+
+		// Response flags
+		{"return-images", "i", "return-images", addResponseFlags},
+		{"return-related", "q", "return-related", addResponseFlags},
+		{"stream", "S", "stream", addResponseFlags},
+
+		// Chat flags
+		{"temperature", "t", "temperature", addChatFlags},
+		{"max-tokens", "T", "max-tokens", addChatFlags},
+		{"top-k", "k", "top-k", addChatFlags},
+
+		// Format flags
+		{"search-mode", "a", "search-mode", addFormatFlags},
+		{"search-context-size", "c", "search-context-size", addFormatFlags},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			tt.setupCmd(cmd)
+
+			// Check short flag exists
+			shortFlag := cmd.PersistentFlags().ShorthandLookup(tt.shortFlag)
+			if shortFlag == nil {
+				t.Errorf("Short flag -%s not found", tt.shortFlag)
+			}
+
+			// Check long flag exists
+			longFlag := cmd.PersistentFlags().Lookup(tt.longFlag)
+			if longFlag == nil {
+				t.Errorf("Long flag --%s not found", tt.longFlag)
+			}
+
+			// Verify they point to the same flag
+			if shortFlag != nil && longFlag != nil {
+				if shortFlag.Name != longFlag.Name {
+					t.Errorf("Short flag -%s and long flag --%s do not point to the same flag",
+						tt.shortFlag, tt.longFlag)
+				}
+			}
+		})
+	}
+}
+
+// TestBackwardCompatibility tests that long flags still work
+func TestBackwardCompatibility(t *testing.T) {
+	tests := []struct {
+		name     string
+		longFlag string
+		setupCmd func(*cobra.Command)
+	}{
+		{"search-domains-long", "search-domains", addSearchFlags},
+		{"search-recency-long", "search-recency", addSearchFlags},
+		{"return-images-long", "return-images", addResponseFlags},
+		{"return-related-long", "return-related", addResponseFlags},
+		{"stream-long", "stream", addResponseFlags},
+		{"temperature-long", "temperature", addChatFlags},
+		{"max-tokens-long", "max-tokens", addChatFlags},
+		{"top-k-long", "top-k", addChatFlags},
+		{"search-mode-long", "search-mode", addFormatFlags},
+		{"search-context-size-long", "search-context-size", addFormatFlags},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			tt.setupCmd(cmd)
+
+			flag := cmd.PersistentFlags().Lookup(tt.longFlag)
+			if flag == nil {
+				t.Errorf("Long flag --%s not found, backward compatibility broken", tt.longFlag)
+			}
+		})
+	}
+}
+
+// TestExistingShortFlags tests that existing short flags are not affected
+func TestExistingShortFlags(t *testing.T) {
+	tests := []struct {
+		name      string
+		shortFlag string
+		longFlag  string
+		setupCmd  func(*cobra.Command)
+	}{
+		{"model", "m", "model", addChatFlags},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := &cobra.Command{}
+			tt.setupCmd(cmd)
+
+			shortFlag := cmd.PersistentFlags().ShorthandLookup(tt.shortFlag)
+			if shortFlag == nil {
+				t.Errorf("Existing short flag -%s was removed", tt.shortFlag)
+			}
+
+			if shortFlag != nil && shortFlag.Name != tt.longFlag {
+				t.Errorf("Short flag -%s does not map to expected long flag --%s",
+					tt.shortFlag, tt.longFlag)
+			}
+		})
+	}
+}
+
+// TestNoFlagConflicts tests that there are no conflicts between short flags
+func TestNoFlagConflicts(t *testing.T) {
+	cmd := &cobra.Command{}
+	addChatFlags(cmd)
+	addSearchFlags(cmd)
+	addResponseFlags(cmd)
+	addFormatFlags(cmd)
+	addDateFlags(cmd)
+	addImageFlags(cmd)
+	addResearchFlags(cmd)
+
+	// Collect all short flags
+	shortFlags := make(map[string]string)
+	cmd.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
+		if flag.Shorthand != "" {
+			if existing, ok := shortFlags[flag.Shorthand]; ok {
+				t.Errorf("Short flag conflict: -%s is used by both --%s and --%s",
+					flag.Shorthand, existing, flag.Name)
+			}
+			shortFlags[flag.Shorthand] = flag.Name
+		}
+	})
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,18 +78,18 @@ func addChatFlags(cmd *cobra.Command) {
 	cmd.PersistentFlags().StringVarP(&model, "model", "m", perplexity.DefaultModel,
 		"List of models: https://docs.perplexity.ai/guides/model-cards")
 	cmd.PersistentFlags().Float64Var(&frequencyPenalty, "frequency-penalty", frequencyPenalty, "Frequency penalty")
-	cmd.PersistentFlags().IntVar(&maxTokens, "max-tokens", maxTokens, "Max tokens")
+	cmd.PersistentFlags().IntVarP(&maxTokens, "max-tokens", "T", maxTokens, "Max tokens")
 	cmd.PersistentFlags().Float64Var(&presencePenalty, "presence-penalty", presencePenalty, "Presence penalty")
-	cmd.PersistentFlags().Float64Var(&temperature, "temperature", temperature, "Temperature")
-	cmd.PersistentFlags().IntVar(&topK, "top-k", topK, "Top K")
+	cmd.PersistentFlags().Float64VarP(&temperature, "temperature", "t", temperature, "Temperature")
+	cmd.PersistentFlags().IntVarP(&topK, "top-k", "k", topK, "Top K")
 	cmd.PersistentFlags().Float64Var(&topP, "top-p", topP, "Top P")
 	cmd.PersistentFlags().DurationVar(&timeout, "timeout", timeout, "HTTP timeout")
 }
 
 func addSearchFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().StringSliceVar(&searchDomains, "search-domains", searchDomains,
+	cmd.PersistentFlags().StringSliceVarP(&searchDomains, "search-domains", "d", searchDomains,
 		"Filter search results to specific domains")
-	cmd.PersistentFlags().StringVar(&searchRecency, "search-recency", searchRecency,
+	cmd.PersistentFlags().StringVarP(&searchRecency, "search-recency", "r", searchRecency,
 		"Filter by time: day, week, month, year")
 	cmd.PersistentFlags().Float64Var(&locationLat, "location-lat", locationLat, "User location latitude")
 	cmd.PersistentFlags().Float64Var(&locationLon, "location-lon", locationLon, "User location longitude")
@@ -97,9 +97,9 @@ func addSearchFlags(cmd *cobra.Command) {
 }
 
 func addResponseFlags(cmd *cobra.Command) {
-	cmd.PersistentFlags().BoolVar(&returnImages, "return-images", returnImages, "Include images in response")
-	cmd.PersistentFlags().BoolVar(&returnRelated, "return-related", returnRelated, "Include related questions")
-	cmd.PersistentFlags().BoolVar(&stream, "stream", stream, "Enable streaming responses")
+	cmd.PersistentFlags().BoolVarP(&returnImages, "return-images", "i", returnImages, "Include images in response")
+	cmd.PersistentFlags().BoolVarP(&returnRelated, "return-related", "q", returnRelated, "Include related questions")
+	cmd.PersistentFlags().BoolVarP(&stream, "stream", "S", stream, "Enable streaming responses")
 }
 
 func addImageFlags(cmd *cobra.Command) {
@@ -113,8 +113,8 @@ func addFormatFlags(cmd *cobra.Command) {
 		responseFormatJSONSchema, "JSON schema for structured output (sonar model only)")
 	cmd.PersistentFlags().StringVar(&responseFormatRegex, "response-format-regex",
 		responseFormatRegex, "Regex pattern for structured output (sonar model only)")
-	cmd.PersistentFlags().StringVar(&searchMode, "search-mode", searchMode, "Search mode: web (default) or academic")
-	cmd.PersistentFlags().StringVar(&searchContextSize, "search-context-size", searchContextSize,
+	cmd.PersistentFlags().StringVarP(&searchMode, "search-mode", "a", searchMode, "Search mode: web (default) or academic")
+	cmd.PersistentFlags().StringVarP(&searchContextSize, "search-context-size", "c", searchContextSize,
 		"Search context size: low, medium, or high")
 }
 


### PR DESCRIPTION
feat(cli): add short flag aliases for frequently used options

Implement 10 short flag aliases to reduce typing overhead:
- Search: -d (domains), -r (recency), -a (mode), -c (context-size)
- Response: -i (images), -q (related), -S (stream)
- Chat: -t (temperature), -T (max-tokens), -k (top-k)

Changes:
- Add VarP functions in cmd/root.go for short flag support
- Update README with short flags in options table and examples
- Add comprehensive test suite in cmd/flags_test.go
- Maintain full backward compatibility with existing long flags

All tests pass, confirming no conflicts and proper flag mapping.
