### PR TITLE
refactor: remove direct os.Exit() calls from command logic

### DIFF
--- a/cmd/mcp-stdio.go
+++ b/cmd/mcp-stdio.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/sgaunet/perplexity-go/v2"
+	clerrors "github.com/sgaunet/pplx/pkg/clerrors"
 	"github.com/spf13/cobra"
 )
 
@@ -20,11 +21,10 @@ var mcpStdioCmd = &cobra.Command{
 	Use:   "mcp-stdio",
 	Short: "Start MCP server in stdio mode",
 	Long:  `Start an MCP (Model Context Protocol) server that exposes Perplexity query functionality`,
-	Run: func(_ *cobra.Command, _ []string) {
+	RunE: func(_ *cobra.Command, _ []string) error {
 		// Check env var PPLX_API_KEY exists
 		if os.Getenv("PPLX_API_KEY") == "" {
-			fmt.Fprintf(os.Stderr, "Error: PPLX_API_KEY env var is not set\n")
-			os.Exit(1)
+			return clerrors.NewConfigError("PPLX_API_KEY environment variable is not set", nil)
 		}
 
 		// Create MCP server
@@ -557,8 +557,8 @@ var mcpStdioCmd = &cobra.Command{
 
 		// Start the stdio server
 		if err := server.ServeStdio(s); err != nil {
-			fmt.Fprintf(os.Stderr, "Server error: %v\n", err)
-			os.Exit(1)
+			return clerrors.NewAPIError("MCP server error", err)
 		}
+		return nil
 	},
 }

--- a/pkg/clerrors/errors.go
+++ b/pkg/clerrors/errors.go
@@ -1,0 +1,109 @@
+// Package clerrors provides custom error types for the Perplexity CLI.
+package clerrors
+
+import "fmt"
+
+// ValidationError represents a validation error for command inputs.
+type ValidationError struct {
+	Field   string
+	Value   string
+	Message string
+}
+
+// NewValidationError creates a new validation error.
+func NewValidationError(field, value, message string) *ValidationError {
+	return &ValidationError{
+		Field:   field,
+		Value:   value,
+		Message: message,
+	}
+}
+
+func (e *ValidationError) Error() string {
+	if e.Value == "" {
+		return fmt.Sprintf("validation failed for %s: %s", e.Field, e.Message)
+	}
+	return fmt.Sprintf("validation failed for %s=%s: %s", e.Field, e.Value, e.Message)
+}
+
+// APIError represents an error from the Perplexity API.
+type APIError struct {
+	StatusCode int
+	Message    string
+	Err        error
+}
+
+// NewAPIError creates a new API error.
+func NewAPIError(message string, err error) *APIError {
+	return &APIError{
+		Message: message,
+		Err:     err,
+	}
+}
+
+func (e *APIError) Error() string {
+	if e.StatusCode > 0 {
+		return fmt.Sprintf("API error (status %d): %s", e.StatusCode, e.Message)
+	}
+	if e.Err != nil {
+		return fmt.Sprintf("API error: %s: %v", e.Message, e.Err)
+	}
+	return "API error: " + e.Message
+}
+
+// Unwrap returns the wrapped error.
+func (e *APIError) Unwrap() error {
+	return e.Err
+}
+
+// ConfigError represents a configuration error.
+type ConfigError struct {
+	Message string
+	Err     error
+}
+
+// NewConfigError creates a new configuration error.
+func NewConfigError(message string, err error) *ConfigError {
+	return &ConfigError{
+		Message: message,
+		Err:     err,
+	}
+}
+
+func (e *ConfigError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("configuration error: %s: %v", e.Message, e.Err)
+	}
+	return "configuration error: " + e.Message
+}
+
+// Unwrap returns the wrapped error.
+func (e *ConfigError) Unwrap() error {
+	return e.Err
+}
+
+// IOError represents an I/O error.
+type IOError struct {
+	Message string
+	Err     error
+}
+
+// NewIOError creates a new I/O error.
+func NewIOError(message string, err error) *IOError {
+	return &IOError{
+		Message: message,
+		Err:     err,
+	}
+}
+
+func (e *IOError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("I/O error: %s: %v", e.Message, e.Err)
+	}
+	return "I/O error: " + e.Message
+}
+
+// Unwrap returns the wrapped error.
+func (e *IOError) Unwrap() error {
+	return e.Err
+}


### PR DESCRIPTION
Removed all direct os.Exit() calls from command files and replaced them with
proper error returns for better testability and error recovery.

Changes:
- Created pkg/clerrors package with custom error types:
  - ValidationError for input validation failures
  - APIError for Perplexity API errors
  - ConfigError for configuration issues
  - IOError for I/O failures

- Updated cmd/root.go:
  - Added centralized error handling with printError() and getExitCode()
  - Used errors.As for proper error type checking (handles wrapped errors)
  - Mapped error types to specific exit codes (2-5)

- Refactored cmd/query.go:
  - Changed Run to RunE to return errors
  - Replaced 18 os.Exit() calls with appropriate error returns
  - All validation errors now return proper ValidationError types

- Refactored cmd/chat.go:
  - Changed Run to RunE to return errors
  - Replaced 10 os.Exit() calls with appropriate error returns

- Refactored cmd/mcp-stdio.go:
  - Changed Run to RunE to return errors
  - Replaced 2 os.Exit() calls with appropriate error returns

Benefits:
- Code is now testable (error cases don't kill test runner)
- Proper error recovery and cleanup via defer
- Structured error information for callers
- Consistent error handling across all commands
- Professional exit codes for different error types

Exit codes:
- 0: Success
- 1: General error
- 2: Validation error
- 3: API error
- 4: Configuration error
- 5: I/O error

Fixes #66