### PR TITLE
docs: add Go 1.24.0 version requirement to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@
 
 It's an unofficial CLI program to query/chat with the [perplexity API](https://www.perplexity.ai/).
 
+## Requirements
+
+- **Go 1.24.0 or later** is required to build from source
+
+If you're installing pre-built binaries, no Go installation is needed.
+
 ## Installation
 
 ## Option 1


### PR DESCRIPTION
Add Requirements section documenting that Go 1.24.0 or later is needed
to build from source. Clarifies that pre-built binaries don't require
Go installation.

Fixes #83