### PR TITLE
chore: fix linter issues and modernize code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 dist
 /pplx
+/.taskmaster

--- a/cmd/config_wizard.go
+++ b/cmd/config_wizard.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -35,7 +36,7 @@ type WizardState struct {
 	enableStream   bool
 	searchFilters  []string
 	apiKey         string
-	customSettings map[string]interface{}
+	customSettings map[string]any
 }
 
 // NewWizardState creates a new wizard state with default values.
@@ -43,7 +44,7 @@ func NewWizardState() *WizardState {
 	return &WizardState{
 		scanner:        bufio.NewScanner(os.Stdin),
 		config:         config.NewConfigData(),
-		customSettings: make(map[string]interface{}),
+		customSettings: make(map[string]any),
 	}
 }
 
@@ -446,10 +447,8 @@ func (w *WizardState) promptChoice(prompt string, validChoices []string) (string
 		}
 
 		choice := strings.TrimSpace(w.scanner.Text())
-		for _, valid := range validChoices {
-			if choice == valid {
-				return choice, nil
-			}
+		if slices.Contains(validChoices, choice) {
+			return choice, nil
 		}
 
 		fmt.Printf("Invalid choice. Please select from: %s\n", strings.Join(validChoices, ", "))
@@ -505,21 +504,11 @@ func (w *WizardState) formatBool(value bool) string {
 // isValidRecency checks if a recency value is valid.
 func isValidRecency(value string) bool {
 	validRecency := []string{"day", "week", "month", "year", "hour"}
-	for _, valid := range validRecency {
-		if value == valid {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(validRecency, value)
 }
 
 // isValidContextSize checks if a context size value is valid.
 func isValidContextSize(value string) bool {
 	validSizes := []string{"low", "medium", "high"}
-	for _, valid := range validSizes {
-		if value == valid {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(validSizes, value)
 }

--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -217,7 +217,7 @@ func (c *Chat) addFormatOptions(opts *[]perplexity.CompletionRequestOption) erro
 		}
 	}
 	if c.options.ResponseFormatJSONSchema != "" {
-		var schema interface{}
+		var schema any
 		err := json.Unmarshal([]byte(c.options.ResponseFormatJSONSchema), &schema)
 		if err != nil {
 			return fmt.Errorf("invalid JSON schema: %w", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -12,10 +12,10 @@ const DefaultProfileName = "default"
 // Config interface defines methods for configuration management.
 type Config interface {
 	// Get retrieves a configuration value by key
-	Get(key string) interface{}
+	Get(key string) any
 
 	// Set sets a configuration value
-	Set(key string, value interface{}) error
+	Set(key string, value any) error
 
 	// Save persists the configuration to disk
 	Save() error
@@ -37,16 +37,16 @@ type Config interface {
 //nolint:revive // ConfigData name is part of public API; renaming would be a breaking change.
 type ConfigData struct {
 	// Defaults contains default values for CLI flags
-	Defaults DefaultsConfig `json:"defaults,omitempty" mapstructure:"defaults" yaml:"defaults,omitempty"`
+	Defaults DefaultsConfig `json:"defaults" mapstructure:"defaults" yaml:"defaults"`
 
 	// Search contains search-related preferences
-	Search SearchConfig `json:"search,omitempty" mapstructure:"search" yaml:"search,omitempty"`
+	Search SearchConfig `json:"search" mapstructure:"search" yaml:"search"`
 
 	// Output contains output-related preferences
-	Output OutputConfig `json:"output,omitempty" mapstructure:"output" yaml:"output,omitempty"`
+	Output OutputConfig `json:"output" mapstructure:"output" yaml:"output"`
 
 	// API contains API configuration
-	API APIConfig `json:"api,omitempty" mapstructure:"api" yaml:"api,omitempty"`
+	API APIConfig `json:"api" mapstructure:"api" yaml:"api"`
 
 	// Profiles contains named configuration profiles
 	Profiles map[string]*Profile `json:"profiles,omitempty" mapstructure:"profiles" yaml:"profiles,omitempty"`
@@ -116,9 +116,9 @@ type APIConfig struct {
 type Profile struct {
 	Name        string         `json:"name"                  mapstructure:"name"        yaml:"name"`
 	Description string         `json:"description,omitempty" mapstructure:"description" yaml:"description,omitempty"`
-	Defaults    DefaultsConfig `json:"defaults,omitempty"    mapstructure:"defaults"    yaml:"defaults,omitempty"`
-	Search      SearchConfig   `json:"search,omitempty"      mapstructure:"search"      yaml:"search,omitempty"`
-	Output      OutputConfig   `json:"output,omitempty"      mapstructure:"output"      yaml:"output,omitempty"`
+	Defaults    DefaultsConfig `json:"defaults"              mapstructure:"defaults"    yaml:"defaults"`
+	Search      SearchConfig   `json:"search"                mapstructure:"search"      yaml:"search"`
+	Output      OutputConfig   `json:"output"                mapstructure:"output"      yaml:"output"`
 }
 
 // ConfigFileInfo represents metadata about a configuration file.

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -246,7 +246,7 @@ func sortConfigFiles(files []ConfigFileInfo) {
 	}
 
 	// Simple bubble sort by precedence, then alphabetically
-	for i := 0; i < len(files); i++ {
+	for i := range files {
 		for j := i + 1; j < len(files); j++ {
 			pi := getPrecedence(files[i].Name)
 			pj := getPrecedence(files[j].Name)

--- a/pkg/config/metadata.go
+++ b/pkg/config/metadata.go
@@ -1,4 +1,3 @@
-// Package config provides configuration metadata and formatting capabilities.
 package config
 
 import (
@@ -49,7 +48,7 @@ type OptionMetadata struct {
 	Description string `json:"description" yaml:"description"`
 
 	// Default is the default value for this option (may be nil)
-	Default interface{} `json:"default,omitempty" yaml:"default,omitempty"`
+	Default any `json:"default,omitempty" yaml:"default,omitempty"`
 
 	// ValidationRules contains human-readable validation constraints
 	ValidationRules []string `json:"validation_rules,omitempty" yaml:"validation_rules,omitempty"`
@@ -641,7 +640,7 @@ func FormatOptions(options []*OptionMetadata, format string) (string, error) {
 }
 
 // formatDefault formats a default value for display.
-func formatDefault(val interface{}) string {
+func formatDefault(val any) string {
 	if val == nil {
 		return "(none)"
 	}


### PR DESCRIPTION
Apply golangci-lint fixes to improve code quality and use Go 1.23+ features.

- Replace interface{} with any type alias
- Use slices.Contains() instead of manual loops
- Use max() built-in for min/max comparisons
- Use strings.SplitSeq() for efficient string iteration
- Use range over int for simplified loops
- Remove ineffective omitempty tags on nested structs
- Remove unused nolint directives
- Add .taskmaster to .gitignore