### PR TITLE
refactor(api): remove deprecated citations fallback logic

### DIFF
--- a/pkg/console/console.go
+++ b/pkg/console/console.go
@@ -210,12 +210,9 @@ func buildJSONResponse(pplxResponse *perplexity.CompletionResponse) map[string]a
 		"usage":   pplxResponse.Usage,
 	}
 
-	// Add search results if available (preferred over deprecated Citations)
+	// Add search results if available
 	if pplxResponse.SearchResults != nil && len(*pplxResponse.SearchResults) > 0 {
 		result["search_results"] = *pplxResponse.SearchResults
-	} else if pplxResponse.Citations != nil && len(*pplxResponse.Citations) > 0 { //nolint:staticcheck // fallback
-		// Fallback to citations for backwards compatibility
-		result["citations"] = *pplxResponse.Citations //nolint:staticcheck // fallback for compatibility
 	}
 
 	// Add images if available

--- a/pkg/mcp/response.go
+++ b/pkg/mcp/response.go
@@ -46,12 +46,9 @@ func (f *ResponseFormatter) buildResponse(response *perplexity.CompletionRespons
 		"usage":   response.Usage,
 	}
 
-	// Add search results if available (preferred over deprecated Citations)
+	// Add search results if available
 	if response.SearchResults != nil && len(*response.SearchResults) > 0 {
 		result["search_results"] = *response.SearchResults
-	} else if response.Citations != nil && len(*response.Citations) > 0 { //nolint:staticcheck // fallback
-		// Fallback to citations for backwards compatibility
-		result["citations"] = *response.Citations //nolint:staticcheck // fallback for compatibility
 	}
 
 	// Add images if available

--- a/pkg/mcp/response_test.go
+++ b/pkg/mcp/response_test.go
@@ -55,36 +55,14 @@ func TestResponseFormatter_Format(t *testing.T) {
 		}
 	})
 
-	t.Run("uses citations fallback when search_results empty", func(t *testing.T) {
-		citations := []string{"citation1", "citation2"}
-		response := &perplexity.CompletionResponse{
-			Choices: []perplexity.Choice{
-				{Message: perplexity.Message{Content: "response"}},
-			},
-			Model:     "sonar",
-			Citations: &citations,
-		}
-
-		result, err := formatter.Format(response)
-		if err != nil {
-			t.Fatalf("Unexpected error: %v", err)
-		}
-
-		if result.IsError {
-			t.Error("Expected success result, got error")
-		}
-	})
-
-	t.Run("prefers search_results over citations", func(t *testing.T) {
+	t.Run("handles response with search_results", func(t *testing.T) {
 		searchResults := []perplexity.SearchResult{{}}
-		citations := []string{"citation1"}
 		response := &perplexity.CompletionResponse{
 			Choices: []perplexity.Choice{
 				{Message: perplexity.Message{Content: "response"}},
 			},
 			Model:         "sonar",
 			SearchResults: &searchResults,
-			Citations:     &citations,
 		}
 
 		result, err := formatter.Format(response)


### PR DESCRIPTION
- Remove citations fallback from console JSON response builder
- Remove citations fallback from MCP response formatter
- Remove citations-related test cases
- Simplify search results handling to use only SearchResults field