### PR TITLE
fix(chat): add hour to search-recency validation

### DIFF
--- a/pkg/chat/chat.go
+++ b/pkg/chat/chat.go
@@ -175,9 +175,9 @@ func (c *Chat) addSearchOptions(opts *[]perplexity.CompletionRequestOption) erro
 		*opts = append(*opts, perplexity.WithSearchDomainFilter(c.options.SearchDomains))
 	}
 	if c.options.SearchRecency != "" {
-		validRecency := map[string]bool{"day": true, "week": true, "month": true, "year": true}
+		validRecency := map[string]bool{"day": true, "week": true, "month": true, "year": true, "hour": true}
 		if !validRecency[c.options.SearchRecency] {
-			return fmt.Errorf("%w: '%s'. Must be one of: day, week, month, year",
+			return fmt.Errorf("%w: '%s'. Must be one of: day, week, month, year, hour",
 				ErrInvalidSearchRecency, c.options.SearchRecency)
 		}
 		*opts = append(*opts, perplexity.WithSearchRecencyFilter(c.options.SearchRecency))


### PR DESCRIPTION
Add "hour" as a valid search-recency value in chat command to match
query command and MCP server validation. This resolves inconsistent
validation across different command interfaces.

Closes #70