### PR TITLE
fix(errors): handle ignored error returns instead of using nolint suppressions

### DIFF
--- a/cmd/config.go
+++ b/cmd/config.go
@@ -771,20 +771,26 @@ func init() {
 // registerConfigFlagCompletions registers completion functions for config command flags.
 func registerConfigFlagCompletions() {
 	// Template name completion for config init --template
-	_ = configInitCmd.RegisterFlagCompletionFunc("template",
+	if err := configInitCmd.RegisterFlagCompletionFunc("template",
 		func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.TemplateNames(), cobra.ShellCompDirectiveNoFileComp
-		})
+		}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to register completion for 'template' flag: %v\n", err)
+	}
 
 	// Section name completion for config options --section
-	_ = configOptionsCmd.RegisterFlagCompletionFunc("section",
+	if err := configOptionsCmd.RegisterFlagCompletionFunc("section",
 		func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.ConfigSections(), cobra.ShellCompDirectiveNoFileComp
-		})
+		}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to register completion for 'section' flag: %v\n", err)
+	}
 
 	// Format completion for config options --format
-	_ = configOptionsCmd.RegisterFlagCompletionFunc("format",
+	if err := configOptionsCmd.RegisterFlagCompletionFunc("format",
 		func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.OutputFormats(), cobra.ShellCompDirectiveNoFileComp
-		})
+		}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to register completion for 'format' flag: %v\n", err)
+	}
 }

--- a/cmd/query.go
+++ b/cmd/query.go
@@ -49,7 +49,9 @@ var queryCmd = &cobra.Command{
 			return clerrors.NewValidationError("user-prompt", "", "user prompt is required")
 		}
 		msg := perplexity.NewMessages(perplexity.WithSystemMessage(systemPrompt))
-		_ = msg.AddUserMessage(userPrompt)
+		if err := msg.AddUserMessage(userPrompt); err != nil {
+			return fmt.Errorf("failed to add user message: %w", err)
+		}
 
 		// Build options list
 		opts := []perplexity.CompletionRequestOption{

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -198,47 +198,63 @@ func addOutputFlags(cmd *cobra.Command) {
 
 func registerFlagCompletions(cmd *cobra.Command) {
 	// Model completion
-	_ = cmd.RegisterFlagCompletionFunc("model",
+	if err := cmd.RegisterFlagCompletionFunc("model",
 		func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.GetModels(), cobra.ShellCompDirectiveNoFileComp
-		})
+		}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to register completion for 'model' flag: %v\n", err)
+	}
 
 	// Search mode completion
-	_ = cmd.RegisterFlagCompletionFunc("search-mode",
+	if err := cmd.RegisterFlagCompletionFunc("search-mode",
 		func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.SearchModes(), cobra.ShellCompDirectiveNoFileComp
-		})
+		}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to register completion for 'search-mode' flag: %v\n", err)
+	}
 
 	// Search recency completion
-	_ = cmd.RegisterFlagCompletionFunc("search-recency",
+	if err := cmd.RegisterFlagCompletionFunc("search-recency",
 		func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.RecencyValues(), cobra.ShellCompDirectiveNoFileComp
-		})
+		}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to register completion for 'search-recency' flag: %v\n", err)
+	}
 
 	// Search context size completion
-	_ = cmd.RegisterFlagCompletionFunc("search-context-size",
+	if err := cmd.RegisterFlagCompletionFunc("search-context-size",
 		func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.ContextSizes(), cobra.ShellCompDirectiveNoFileComp
-		})
+		}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to register completion for 'search-context-size' flag: %v\n", err)
+	}
 
 	// Reasoning effort completion
-	_ = cmd.RegisterFlagCompletionFunc("reasoning-effort",
+	if err := cmd.RegisterFlagCompletionFunc("reasoning-effort",
 		func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.ReasoningEfforts(), cobra.ShellCompDirectiveNoFileComp
-		})
+		}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to register completion for 'reasoning-effort' flag: %v\n", err)
+	}
 
 	// Image formats completion
-	_ = cmd.RegisterFlagCompletionFunc("image-formats",
+	if err := cmd.RegisterFlagCompletionFunc("image-formats",
 		func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 			return completion.ImageFormats(), cobra.ShellCompDirectiveNoFileComp
-		})
+		}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to register completion for 'image-formats' flag: %v\n", err)
+	}
 
 	// Domain suggestions (for both search-domains and image-domains)
 	domainCompletion := func(_ *cobra.Command, _ []string, _ string) ([]string, cobra.ShellCompDirective) {
 		return completion.CommonDomains(), cobra.ShellCompDirectiveNoFileComp
 	}
-	_ = cmd.RegisterFlagCompletionFunc("search-domains", domainCompletion)
-	_ = cmd.RegisterFlagCompletionFunc("image-domains", domainCompletion)
+	if err := cmd.RegisterFlagCompletionFunc("search-domains", domainCompletion); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to register completion for 'search-domains' flag: %v\n", err)
+	}
+	if err := cmd.RegisterFlagCompletionFunc("image-domains", domainCompletion); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to register completion for 'image-domains' flag: %v\n", err)
+	}
 }
 
 func init() {

--- a/pkg/mcp/handler.go
+++ b/pkg/mcp/handler.go
@@ -36,7 +36,9 @@ func (h *QueryHandler) Handle(
 
 	// Build messages
 	msg := perplexity.NewMessages(perplexity.WithSystemMessage(params.SystemPrompt))
-	_ = msg.AddUserMessage(params.UserPrompt)
+	if err := msg.AddUserMessage(params.UserPrompt); err != nil {
+		return nil, fmt.Errorf("failed to add user message: %w", err)
+	}
 
 	// Build request options
 	opts, err := h.buildRequestOptions(params, msg)

--- a/pkg/mcp/handler_test.go
+++ b/pkg/mcp/handler_test.go
@@ -176,7 +176,9 @@ func TestQueryHandler_BuildRequestOptions(t *testing.T) {
 		}
 
 		msg := perplexity.NewMessages(perplexity.WithSystemMessage(params.SystemPrompt))
-		_ = msg.AddUserMessage(params.UserPrompt)
+		if err := msg.AddUserMessage(params.UserPrompt); err != nil {
+			t.Fatalf("Failed to add user message: %v", err)
+		}
 
 		opts, err := handler.buildRequestOptions(params, msg)
 		if err != nil {
@@ -196,7 +198,9 @@ func TestQueryHandler_BuildRequestOptions(t *testing.T) {
 		}
 
 		msg := perplexity.NewMessages()
-		_ = msg.AddUserMessage(params.UserPrompt)
+		if err := msg.AddUserMessage(params.UserPrompt); err != nil {
+			t.Fatalf("Failed to add user message: %v", err)
+		}
 
 		opts, err := handler.buildRequestOptions(params, msg)
 		if err != nil {
@@ -218,7 +222,9 @@ func TestQueryHandler_BuildRequestOptions(t *testing.T) {
 		}
 
 		msg := perplexity.NewMessages()
-		_ = msg.AddUserMessage(params.UserPrompt)
+		if err := msg.AddUserMessage(params.UserPrompt); err != nil {
+			t.Fatalf("Failed to add user message: %v", err)
+		}
 
 		opts, err := handler.buildRequestOptions(params, msg)
 		if err != nil {
@@ -240,7 +246,9 @@ func TestQueryHandler_BuildRequestOptions(t *testing.T) {
 		}
 
 		msg := perplexity.NewMessages()
-		_ = msg.AddUserMessage(params.UserPrompt)
+		if err := msg.AddUserMessage(params.UserPrompt); err != nil {
+			t.Fatalf("Failed to add user message: %v", err)
+		}
 
 		opts, err := handler.buildRequestOptions(params, msg)
 		if err != nil {
@@ -283,7 +291,9 @@ func TestQueryHandler_BuildRequestOptions(t *testing.T) {
 				}
 
 				msg := perplexity.NewMessages()
-				_ = msg.AddUserMessage(params.UserPrompt)
+				if err := msg.AddUserMessage(params.UserPrompt); err != nil {
+			t.Fatalf("Failed to add user message: %v", err)
+		}
 
 				_, err := handler.buildRequestOptions(params, msg)
 				if err == nil {
@@ -309,7 +319,9 @@ func TestQueryHandler_BuildRequestOptions(t *testing.T) {
 		}
 
 		msg := perplexity.NewMessages()
-		_ = msg.AddUserMessage(params.UserPrompt)
+		if err := msg.AddUserMessage(params.UserPrompt); err != nil {
+			t.Fatalf("Failed to add user message: %v", err)
+		}
 
 		opts, err := handler.buildRequestOptions(params, msg)
 		if err != nil {
@@ -330,7 +342,9 @@ func TestQueryHandler_BuildRequestOptions(t *testing.T) {
 		}
 
 		msg := perplexity.NewMessages()
-		_ = msg.AddUserMessage(params.UserPrompt)
+		if err := msg.AddUserMessage(params.UserPrompt); err != nil {
+			t.Fatalf("Failed to add user message: %v", err)
+		}
 
 		_, err := handler.buildRequestOptions(params, msg)
 		if err == nil {
@@ -351,7 +365,9 @@ func TestQueryHandler_BuildRequestOptions(t *testing.T) {
 		}
 
 		msg := perplexity.NewMessages()
-		_ = msg.AddUserMessage(params.UserPrompt)
+		if err := msg.AddUserMessage(params.UserPrompt); err != nil {
+			t.Fatalf("Failed to add user message: %v", err)
+		}
 
 		opts, err := handler.buildRequestOptions(params, msg)
 		if err != nil {
@@ -371,7 +387,9 @@ func TestQueryHandler_BuildRequestOptions(t *testing.T) {
 		}
 
 		msg := perplexity.NewMessages()
-		_ = msg.AddUserMessage(params.UserPrompt)
+		if err := msg.AddUserMessage(params.UserPrompt); err != nil {
+			t.Fatalf("Failed to add user message: %v", err)
+		}
 
 		opts, err := handler.buildRequestOptions(params, msg)
 		if err != nil {
@@ -403,7 +421,9 @@ func TestQueryHandler_BuildRequestOptions(t *testing.T) {
 		}
 
 		msg := perplexity.NewMessages(perplexity.WithSystemMessage(params.SystemPrompt))
-		_ = msg.AddUserMessage(params.UserPrompt)
+		if err := msg.AddUserMessage(params.UserPrompt); err != nil {
+			t.Fatalf("Failed to add user message: %v", err)
+		}
 
 		opts, err := handler.buildRequestOptions(params, msg)
 		if err != nil {
@@ -424,7 +444,9 @@ func TestQueryHandler_BuildRequestOptions(t *testing.T) {
 		}
 
 		msg := perplexity.NewMessages()
-		_ = msg.AddUserMessage(params.UserPrompt)
+		if err := msg.AddUserMessage(params.UserPrompt); err != nil {
+			t.Fatalf("Failed to add user message: %v", err)
+		}
 
 		_, err := handler.buildRequestOptions(params, msg)
 		if err == nil {


### PR DESCRIPTION
Replace 22 instances of ignored error returns with proper error handling:
- Add inline error handling for 11 flag completion registrations
- Propagate errors for 11 AddUserMessage calls with proper context
- Update test assertions to fail on unexpected errors

Flag completion errors now print warnings to stderr (init-time errors)
while AddUserMessage errors are properly propagated for runtime handling.

Fixes #72