### PR TITLE
feat(errors): add context to error messages across codebase

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -81,7 +81,7 @@ PowerShell:
 		if completionOutputFile != "" {
 			file, err := os.Create(completionOutputFile) // #nosec G304
 			if err != nil {
-				return fmt.Errorf("failed to create output file: %w", err)
+				return fmt.Errorf("failed to create %s completion output file %s: %w", shell, completionOutputFile, err)
 			}
 			defer func() {
 				if closeErr := file.Close(); closeErr != nil {
@@ -106,7 +106,7 @@ var bashCmd = &cobra.Command{
 		if completionOutputFile != "" {
 			file, err := os.Create(completionOutputFile) // #nosec G304
 			if err != nil {
-				return fmt.Errorf("failed to create output file: %w", err)
+				return fmt.Errorf("failed to create bash completion output file %s: %w", completionOutputFile, err)
 			}
 			defer func() {
 				if closeErr := file.Close(); closeErr != nil {
@@ -132,7 +132,7 @@ var zshCmd = &cobra.Command{
 		if completionOutputFile != "" {
 			file, err := os.Create(completionOutputFile) // #nosec G304
 			if err != nil {
-				return fmt.Errorf("failed to create output file: %w", err)
+				return fmt.Errorf("failed to create zsh completion output file %s: %w", completionOutputFile, err)
 			}
 			defer func() {
 				if closeErr := file.Close(); closeErr != nil {
@@ -158,7 +158,7 @@ var fishCmd = &cobra.Command{
 		if completionOutputFile != "" {
 			file, err := os.Create(completionOutputFile) // #nosec G304
 			if err != nil {
-				return fmt.Errorf("failed to create output file: %w", err)
+				return fmt.Errorf("failed to create fish completion output file %s: %w", completionOutputFile, err)
 			}
 			defer func() {
 				if closeErr := file.Close(); closeErr != nil {
@@ -184,7 +184,7 @@ var powershellCmd = &cobra.Command{
 		if completionOutputFile != "" {
 			file, err := os.Create(completionOutputFile) // #nosec G304
 			if err != nil {
-				return fmt.Errorf("failed to create output file: %w", err)
+				return fmt.Errorf("failed to create powershell completion output file %s: %w", completionOutputFile, err)
 			}
 			defer func() {
 				if closeErr := file.Close(); closeErr != nil {
@@ -315,7 +315,7 @@ func getBashInstallTarget(homeDir string) (*shellInstallTarget, error) {
 		// Fallback to user directory
 		targetPath = filepath.Join(homeDir, ".bash_completion.d", "pplx")
 		if err := os.MkdirAll(filepath.Dir(targetPath), dirPerms); err != nil { // #nosec G301
-			return nil, fmt.Errorf("failed to create directory: %w", err)
+			return nil, fmt.Errorf("failed to create directory %s: %w", filepath.Dir(targetPath), err)
 		}
 		return &shellInstallTarget{
 			targetPath: targetPath,
@@ -330,7 +330,7 @@ func getBashInstallTarget(homeDir string) (*shellInstallTarget, error) {
 func getZshInstallTarget(homeDir string) (*shellInstallTarget, error) {
 	targetPath := filepath.Join(homeDir, ".zsh", "completions", "_pplx")
 	if err := os.MkdirAll(filepath.Dir(targetPath), dirPerms); err != nil { // #nosec G301
-		return nil, fmt.Errorf("failed to create directory: %w", err)
+		return nil, fmt.Errorf("failed to create directory %s: %w", filepath.Dir(targetPath), err)
 	}
 	return &shellInstallTarget{
 		targetPath: targetPath,
@@ -344,7 +344,7 @@ func getZshInstallTarget(homeDir string) (*shellInstallTarget, error) {
 func getFishInstallTarget(homeDir string) (*shellInstallTarget, error) {
 	configDir := filepath.Join(homeDir, ".config", "fish", "completions")
 	if err := os.MkdirAll(configDir, dirPerms); err != nil { // #nosec G301
-		return nil, fmt.Errorf("failed to create directory: %w", err)
+		return nil, fmt.Errorf("failed to create directory %s: %w", configDir, err)
 	}
 	return &shellInstallTarget{
 		targetPath: filepath.Join(configDir, "pplx.fish"),
@@ -354,7 +354,7 @@ func getFishInstallTarget(homeDir string) (*shellInstallTarget, error) {
 func getPowershellInstallTarget(homeDir string) (*shellInstallTarget, error) {
 	targetPath := filepath.Join(homeDir, "Documents", "PowerShell", "Scripts", "pplx-completion.ps1")
 	if err := os.MkdirAll(filepath.Dir(targetPath), dirPerms); err != nil { // #nosec G301
-		return nil, fmt.Errorf("failed to create directory: %w", err)
+		return nil, fmt.Errorf("failed to create directory %s: %w", filepath.Dir(targetPath), err)
 	}
 	return &shellInstallTarget{
 		targetPath:        targetPath,
@@ -366,7 +366,7 @@ func getPowershellInstallTarget(homeDir string) (*shellInstallTarget, error) {
 func installCompletion(rootCmd *cobra.Command, shell string) error {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
+		return fmt.Errorf("failed to get home directory for %s completion installation: %w", shell, err)
 	}
 
 	target, err := getInstallTarget(homeDir, shell)
@@ -377,7 +377,7 @@ func installCompletion(rootCmd *cobra.Command, shell string) error {
 	// Create the completion file
 	file, err := os.Create(target.targetPath)
 	if err != nil {
-		return fmt.Errorf("failed to create completion file: %w", err)
+		return fmt.Errorf("failed to create %s completion file %s: %w", shell, target.targetPath, err)
 	}
 	defer func() {
 		if closeErr := file.Close(); closeErr != nil {
@@ -387,7 +387,7 @@ func installCompletion(rootCmd *cobra.Command, shell string) error {
 
 	// Generate completion script
 	if err := generateCompletion(rootCmd, shell, file); err != nil {
-		return fmt.Errorf("failed to generate completion: %w", err)
+		return fmt.Errorf("failed to generate %s completion: %w", shell, err)
 	}
 
 	fmt.Printf("✓ Shell completion installed to: %s\n", target.targetPath)
@@ -434,7 +434,7 @@ func getUninstallPaths(homeDir, shell string) ([]string, error) {
 func uninstallCompletion(shell string) error {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
+		return fmt.Errorf("failed to get home directory for %s completion uninstallation: %w", shell, err)
 	}
 
 	targetPaths, err := getUninstallPaths(homeDir, shell)

--- a/pkg/completion/models.go
+++ b/pkg/completion/models.go
@@ -44,12 +44,12 @@ func KnownModels() []string {
 func GetCacheDir() (string, error) {
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("failed to get home directory: %w", err)
+		return "", fmt.Errorf("failed to get home directory for cache: %w", err)
 	}
 
 	cacheDir := filepath.Join(homeDir, ".cache", "pplx")
 	if err := os.MkdirAll(cacheDir, cacheDirPerms); err != nil { // #nosec G301
-		return "", fmt.Errorf("failed to create cache directory: %w", err)
+		return "", fmt.Errorf("failed to create cache directory %s: %w", cacheDir, err)
 	}
 
 	return cacheDir, nil
@@ -72,7 +72,7 @@ func GetCachedModels() ([]string, error) {
 			return KnownModels(), nil
 		}
 		// Return error for other read failures
-		return KnownModels(), fmt.Errorf("failed to read cache file: %w", err)
+		return KnownModels(), fmt.Errorf("failed to read cache file %s: %w", cachePath, err)
 	}
 
 	// Parse cache
@@ -107,11 +107,11 @@ func SaveModelsToCache(models []string) error {
 
 	data, err := json.MarshalIndent(cache, "", "  ")
 	if err != nil {
-		return fmt.Errorf("failed to marshal cache data: %w", err)
+		return fmt.Errorf("failed to marshal model cache data: %w", err)
 	}
 
 	if err := os.WriteFile(cachePath, data, cacheFilePerms); err != nil { // #nosec G306
-		return fmt.Errorf("failed to write cache file: %w", err)
+		return fmt.Errorf("failed to write cache file %s: %w", cachePath, err)
 	}
 
 	return nil

--- a/pkg/config/loader.go
+++ b/pkg/config/loader.go
@@ -63,13 +63,13 @@ func (l *Loader) Load() error {
 		// It's okay if config file doesn't exist
 		var configFileNotFoundError viper.ConfigFileNotFoundError
 		if !errors.As(err, &configFileNotFoundError) {
-			return fmt.Errorf("error reading config file: %w", err)
+			return fmt.Errorf("error reading config file %s: %w", l.viper.ConfigFileUsed(), err)
 		}
 	}
 
 	// Unmarshal config into data structure
 	if err := l.viper.Unmarshal(l.data); err != nil {
-		return fmt.Errorf("error unmarshaling config: %w", err)
+		return fmt.Errorf("error unmarshaling config from %s: %w", l.viper.ConfigFileUsed(), err)
 	}
 
 	return nil
@@ -84,7 +84,7 @@ func (l *Loader) LoadFrom(path string) error {
 	}
 
 	if err := l.viper.Unmarshal(l.data); err != nil {
-		return fmt.Errorf("error unmarshaling config: %w", err)
+		return fmt.Errorf("error unmarshaling config from %s: %w", path, err)
 	}
 
 	return nil
@@ -167,7 +167,7 @@ func ListConfigFiles() ([]ConfigFileInfo, error) {
 	// Read directory contents
 	entries, err := os.ReadDir(configDir)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read config directory: %w", err)
+		return nil, fmt.Errorf("failed to read config directory %s: %w", configDir, err)
 	}
 
 	files := make([]ConfigFileInfo, 0, len(entries))
@@ -336,7 +336,7 @@ func FormatTimestamp(t time.Time) string {
 func GetConfigFileInfo(path string) (*ConfigFileInfo, error) {
 	info, err := os.Stat(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to stat file: %w", err)
+		return nil, fmt.Errorf("failed to stat file %s: %w", path, err)
 	}
 
 	if info.IsDir() {


### PR DESCRIPTION
Enhance error messages by including contextual information (file paths,
template names, profile names, shell types) to help users quickly identify
and resolve issues.

Changes:
- pkg/config/loader.go: add config file paths from viper.ConfigFileUsed()
- cmd/config.go: add config paths, template/profile names (quoted), operation context
- cmd/completion.go: add shell types and output file paths to completion errors
- pkg/completion/models.go: add cache directory and file paths
- cmd/query.go: enhance user message error and reduce cyclomatic complexity

Before: "failed to load config: %w"
After: "failed to load config from %s: %w"

All error wrapping preserved (%w) for errors.Is()/errors.As() compatibility.
Security maintained - no sensitive data exposed in error messages.

Fixes #76