### PR TITLE
test(config): add comprehensive edge case tests for config package

### DIFF
--- a/pkg/config/envexpand_test.go
+++ b/pkg/config/envexpand_test.go
@@ -1,0 +1,699 @@
+package config
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+// setupEnvTest sets up environment variables for a test and returns cleanup function.
+func setupEnvTest(t *testing.T, vars map[string]string) func() {
+	t.Helper()
+
+	// Store original values
+	originals := make(map[string]string)
+	for key := range vars {
+		if val, exists := os.LookupEnv(key); exists {
+			originals[key] = val
+		}
+	}
+
+	// Set new values
+	for key, val := range vars {
+		if err := os.Setenv(key, val); err != nil {
+			t.Fatalf("Failed to set env var %s: %v", key, err)
+		}
+	}
+
+	// Return cleanup function
+	return func() {
+		for key := range vars {
+			if orig, had := originals[key]; had {
+				_ = os.Setenv(key, orig)
+			} else {
+				_ = os.Unsetenv(key)
+			}
+		}
+	}
+}
+
+// createTestConfig creates a ConfigData with env var placeholders for testing.
+func createTestConfig() *ConfigData {
+	return &ConfigData{
+		API: APIConfig{
+			Key:     "$API_KEY",
+			BaseURL: "${BASE_URL}",
+		},
+		Defaults: DefaultsConfig{
+			Model:   "${MODEL}",
+			Timeout: "$TIMEOUT",
+		},
+		Search: SearchConfig{
+			Domains:         []string{"$DOMAIN1", "${DOMAIN2}", "literal.com"},
+			LocationCountry: "${COUNTRY}",
+		},
+		Output: OutputConfig{
+			ImageDomains: []string{"${IMG_DOMAIN1}", "$IMG_DOMAIN2"},
+			ImageFormats: []string{"$FORMAT1", "png"},
+		},
+	}
+}
+
+// =============================================================================
+// Category 1: Basic Syntax Variants (4 tests)
+// =============================================================================
+
+func TestExpandEnvVars_SimpleDollarSyntax(t *testing.T) {
+	cleanup := setupEnvTest(t, map[string]string{
+		"TEST_VAR": "test-value",
+	})
+	defer cleanup()
+
+	cfg := &ConfigData{
+		API: APIConfig{
+			Key: "$TEST_VAR",
+		},
+	}
+
+	ExpandEnvVars(cfg)
+
+	if cfg.API.Key != "test-value" {
+		t.Errorf("Expected 'test-value', got '%s'", cfg.API.Key)
+	}
+}
+
+func TestExpandEnvVars_BracedSyntax(t *testing.T) {
+	cleanup := setupEnvTest(t, map[string]string{
+		"TEST_VAR": "braced-value",
+	})
+	defer cleanup()
+
+	cfg := &ConfigData{
+		API: APIConfig{
+			BaseURL: "${TEST_VAR}",
+		},
+	}
+
+	ExpandEnvVars(cfg)
+
+	if cfg.API.BaseURL != "braced-value" {
+		t.Errorf("Expected 'braced-value', got '%s'", cfg.API.BaseURL)
+	}
+}
+
+func TestExpandEnvVars_MixedSyntax(t *testing.T) {
+	cleanup := setupEnvTest(t, map[string]string{
+		"VAR1": "first",
+		"VAR2": "second",
+	})
+	defer cleanup()
+
+	cfg := &ConfigData{
+		Defaults: DefaultsConfig{
+			Model: "$VAR1 and ${VAR2}",
+		},
+	}
+
+	ExpandEnvVars(cfg)
+
+	expected := "first and second"
+	if cfg.Defaults.Model != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, cfg.Defaults.Model)
+	}
+}
+
+func TestExpandEnvVars_MultipleVarsInString(t *testing.T) {
+	cleanup := setupEnvTest(t, map[string]string{
+		"HOST": "example.com",
+		"PORT": "8080",
+		"PATH": "/api/v1",
+	})
+	defer cleanup()
+
+	cfg := &ConfigData{
+		API: APIConfig{
+			BaseURL: "https://$HOST:$PORT$PATH",
+		},
+	}
+
+	ExpandEnvVars(cfg)
+
+	expected := "https://example.com:8080/api/v1"
+	if cfg.API.BaseURL != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, cfg.API.BaseURL)
+	}
+}
+
+// =============================================================================
+// Category 2: Undefined/Empty Variables (3 tests)
+// =============================================================================
+
+func TestExpandEnvVars_UndefinedVariable(t *testing.T) {
+	// Ensure variable doesn't exist
+	_ = os.Unsetenv("UNDEFINED_VAR_12345")
+
+	cfg := &ConfigData{
+		API: APIConfig{
+			Key: "$UNDEFINED_VAR_12345",
+		},
+	}
+
+	ExpandEnvVars(cfg)
+
+	// os.ExpandEnv replaces undefined vars with empty string
+	if cfg.API.Key != "" {
+		t.Errorf("Expected empty string for undefined var, got '%s'", cfg.API.Key)
+	}
+}
+
+func TestExpandEnvVars_EmptyVariable(t *testing.T) {
+	cleanup := setupEnvTest(t, map[string]string{
+		"EMPTY_VAR": "",
+	})
+	defer cleanup()
+
+	cfg := &ConfigData{
+		Defaults: DefaultsConfig{
+			Model: "${EMPTY_VAR}",
+		},
+	}
+
+	ExpandEnvVars(cfg)
+
+	if cfg.Defaults.Model != "" {
+		t.Errorf("Expected empty string, got '%s'", cfg.Defaults.Model)
+	}
+}
+
+func TestExpandEnvVars_WhitespaceOnlyValue(t *testing.T) {
+	cleanup := setupEnvTest(t, map[string]string{
+		"WHITESPACE_VAR": "   ",
+	})
+	defer cleanup()
+
+	cfg := &ConfigData{
+		Search: SearchConfig{
+			LocationCountry: "$WHITESPACE_VAR",
+		},
+	}
+
+	ExpandEnvVars(cfg)
+
+	if cfg.Search.LocationCountry != "   " {
+		t.Errorf("Expected '   ', got '%s'", cfg.Search.LocationCountry)
+	}
+}
+
+// =============================================================================
+// Category 3: Special Characters in Values (4 tests)
+// =============================================================================
+
+func TestExpandEnvVars_URLsWithProtocols(t *testing.T) {
+	cleanup := setupEnvTest(t, map[string]string{
+		"API_URL": "https://api.perplexity.ai/v1",
+	})
+	defer cleanup()
+
+	cfg := &ConfigData{
+		API: APIConfig{
+			BaseURL: "${API_URL}",
+		},
+	}
+
+	ExpandEnvVars(cfg)
+
+	expected := "https://api.perplexity.ai/v1"
+	if cfg.API.BaseURL != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, cfg.API.BaseURL)
+	}
+}
+
+func TestExpandEnvVars_SpecialCharacters(t *testing.T) {
+	cleanup := setupEnvTest(t, map[string]string{
+		"SPECIAL_CHARS": "test@#%&*!()[]",
+	})
+	defer cleanup()
+
+	cfg := &ConfigData{
+		API: APIConfig{
+			Key: "$SPECIAL_CHARS",
+		},
+	}
+
+	ExpandEnvVars(cfg)
+
+	expected := "test@#%&*!()[]"
+	if cfg.API.Key != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, cfg.API.Key)
+	}
+}
+
+func TestExpandEnvVars_QuotesInValues(t *testing.T) {
+	testCases := []struct {
+		name     string
+		envValue string
+	}{
+		{"single quotes", "test'value'here"},
+		{"double quotes", `test"value"here`},
+		{"mixed quotes", `test'mixed"quotes`},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cleanup := setupEnvTest(t, map[string]string{
+				"QUOTE_VAR": tc.envValue,
+			})
+			defer cleanup()
+
+			cfg := &ConfigData{
+				Defaults: DefaultsConfig{
+					Model: "${QUOTE_VAR}",
+				},
+			}
+
+			ExpandEnvVars(cfg)
+
+			if cfg.Defaults.Model != tc.envValue {
+				t.Errorf("Expected '%s', got '%s'", tc.envValue, cfg.Defaults.Model)
+			}
+		})
+	}
+}
+
+func TestExpandEnvVars_UnicodeCharacters(t *testing.T) {
+	testCases := []struct {
+		name     string
+		envValue string
+	}{
+		{"emoji", "test-🚀-value"},
+		{"accented", "café-résumé"},
+		{"chinese", "测试值"},
+		{"mixed", "test-café-🚀-测试"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cleanup := setupEnvTest(t, map[string]string{
+				"UNICODE_VAR": tc.envValue,
+			})
+			defer cleanup()
+
+			cfg := &ConfigData{
+				Search: SearchConfig{
+					LocationCountry: "$UNICODE_VAR",
+				},
+			}
+
+			ExpandEnvVars(cfg)
+
+			if cfg.Search.LocationCountry != tc.envValue {
+				t.Errorf("Expected '%s', got '%s'", tc.envValue, cfg.Search.LocationCountry)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// Category 4: Nested Structures (4 tests)
+// =============================================================================
+
+func TestExpandEnvVars_InStringArrays(t *testing.T) {
+	cleanup := setupEnvTest(t, map[string]string{
+		"DOMAIN1": "example.com",
+		"DOMAIN2": "test.org",
+	})
+	defer cleanup()
+
+	cfg := &ConfigData{
+		Search: SearchConfig{
+			Domains: []string{"$DOMAIN1", "${DOMAIN2}", "literal.com"},
+		},
+	}
+
+	ExpandEnvVars(cfg)
+
+	expected := []string{"example.com", "test.org", "literal.com"}
+	if len(cfg.Search.Domains) != len(expected) {
+		t.Fatalf("Expected %d domains, got %d", len(expected), len(cfg.Search.Domains))
+	}
+
+	for i, exp := range expected {
+		if cfg.Search.Domains[i] != exp {
+			t.Errorf("Domain[%d]: expected '%s', got '%s'", i, exp, cfg.Search.Domains[i])
+		}
+	}
+}
+
+func TestExpandEnvVars_InAllConfigSections(t *testing.T) {
+	cleanup := setupEnvTest(t, map[string]string{
+		"API_KEY":    "sk-test-123",
+		"BASE_URL":   "https://api.test.com",
+		"MODEL":      "sonar-pro",
+		"TIMEOUT":    "30s",
+		"DOMAIN":     "example.com",
+		"COUNTRY":    "US",
+		"IMG_DOMAIN": "images.test.com",
+		"FORMAT":     "jpg",
+	})
+	defer cleanup()
+
+	cfg := &ConfigData{
+		API: APIConfig{
+			Key:     "$API_KEY",
+			BaseURL: "${BASE_URL}",
+		},
+		Defaults: DefaultsConfig{
+			Model:   "$MODEL",
+			Timeout: "${TIMEOUT}",
+		},
+		Search: SearchConfig{
+			Domains:         []string{"$DOMAIN"},
+			LocationCountry: "$COUNTRY",
+		},
+		Output: OutputConfig{
+			ImageDomains: []string{"${IMG_DOMAIN}"},
+			ImageFormats: []string{"$FORMAT"},
+		},
+	}
+
+	ExpandEnvVars(cfg)
+
+	// Verify API section
+	if cfg.API.Key != "sk-test-123" {
+		t.Errorf("API.Key: expected 'sk-test-123', got '%s'", cfg.API.Key)
+	}
+	if cfg.API.BaseURL != "https://api.test.com" {
+		t.Errorf("API.BaseURL: expected 'https://api.test.com', got '%s'", cfg.API.BaseURL)
+	}
+
+	// Verify Defaults section
+	if cfg.Defaults.Model != "sonar-pro" {
+		t.Errorf("Defaults.Model: expected 'sonar-pro', got '%s'", cfg.Defaults.Model)
+	}
+	if cfg.Defaults.Timeout != "30s" {
+		t.Errorf("Defaults.Timeout: expected '30s', got '%s'", cfg.Defaults.Timeout)
+	}
+
+	// Verify Search section
+	if len(cfg.Search.Domains) != 1 || cfg.Search.Domains[0] != "example.com" {
+		t.Errorf("Search.Domains: expected ['example.com'], got %v", cfg.Search.Domains)
+	}
+	if cfg.Search.LocationCountry != "US" {
+		t.Errorf("Search.LocationCountry: expected 'US', got '%s'", cfg.Search.LocationCountry)
+	}
+
+	// Verify Output section
+	if len(cfg.Output.ImageDomains) != 1 || cfg.Output.ImageDomains[0] != "images.test.com" {
+		t.Errorf("Output.ImageDomains: expected ['images.test.com'], got %v", cfg.Output.ImageDomains)
+	}
+	if len(cfg.Output.ImageFormats) != 1 || cfg.Output.ImageFormats[0] != "jpg" {
+		t.Errorf("Output.ImageFormats: expected ['jpg'], got %v", cfg.Output.ImageFormats)
+	}
+}
+
+func TestExpandEnvVars_PreservesNonEnvValues(t *testing.T) {
+	cleanup := setupEnvTest(t, map[string]string{
+		"TEST_VAR": "replaced",
+	})
+	defer cleanup()
+
+	cfg := &ConfigData{
+		API: APIConfig{
+			Key:     "$TEST_VAR",
+			BaseURL: "https://literal.com",
+		},
+		Defaults: DefaultsConfig{
+			Model:   "literal-model",
+			Timeout: "30s",
+		},
+	}
+
+	ExpandEnvVars(cfg)
+
+	// Verify env var was expanded
+	if cfg.API.Key != "replaced" {
+		t.Errorf("API.Key should be expanded, got '%s'", cfg.API.Key)
+	}
+
+	// Verify literals were preserved
+	if cfg.API.BaseURL != "https://literal.com" {
+		t.Errorf("API.BaseURL should be preserved, got '%s'", cfg.API.BaseURL)
+	}
+	if cfg.Defaults.Model != "literal-model" {
+		t.Errorf("Defaults.Model should be preserved, got '%s'", cfg.Defaults.Model)
+	}
+	if cfg.Defaults.Timeout != "30s" {
+		t.Errorf("Defaults.Timeout should be preserved, got '%s'", cfg.Defaults.Timeout)
+	}
+}
+
+func TestExpandEnvVars_MixedArrayContent(t *testing.T) {
+	cleanup := setupEnvTest(t, map[string]string{
+		"DYNAMIC1": "dynamic-first.com",
+		"DYNAMIC2": "dynamic-second.com",
+	})
+	defer cleanup()
+
+	cfg := &ConfigData{
+		Search: SearchConfig{
+			Domains: []string{
+				"$DYNAMIC1",
+				"literal.com",
+				"${DYNAMIC2}",
+				"another-literal.org",
+			},
+		},
+	}
+
+	ExpandEnvVars(cfg)
+
+	expected := []string{
+		"dynamic-first.com",
+		"literal.com",
+		"dynamic-second.com",
+		"another-literal.org",
+	}
+
+	if len(cfg.Search.Domains) != len(expected) {
+		t.Fatalf("Expected %d domains, got %d", len(expected), len(cfg.Search.Domains))
+	}
+
+	for i, exp := range expected {
+		if cfg.Search.Domains[i] != exp {
+			t.Errorf("Domain[%d]: expected '%s', got '%s'", i, exp, cfg.Search.Domains[i])
+		}
+	}
+}
+
+// =============================================================================
+// Category 5: Edge Cases (5 tests)
+// =============================================================================
+
+func TestExpandEnvVars_MalformedSyntax(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"empty braces", "${}", ""},                   // os.ExpandEnv expands ${} to empty string
+		{"unclosed brace", "${VAR", "VAR"},            // os.ExpandEnv treats as literal after $
+		{"lone dollar", "test $ value", "test $ value"}, // Lone $ preserved
+		{"dollar at end", "test$", "test$"},           // $ at end preserved
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &ConfigData{
+				API: APIConfig{
+					Key: tc.input,
+				},
+			}
+
+			ExpandEnvVars(cfg)
+
+			if cfg.API.Key != tc.expected {
+				t.Errorf("Expected '%s', got '%s'", tc.expected, cfg.API.Key)
+			}
+		})
+	}
+}
+
+func TestExpandEnvVars_EscapedDollarSigns(t *testing.T) {
+	// Note: os.ExpandEnv behavior with $$ varies by context
+	// In practice, $$VAR becomes "VAR" (the $$ escapes the variable expansion)
+	cfg := &ConfigData{
+		API: APIConfig{
+			Key: "$$VAR",
+		},
+	}
+
+	ExpandEnvVars(cfg)
+
+	// os.ExpandEnv behavior: $$VAR → VAR (escaped expansion)
+	expected := "VAR"
+	if cfg.API.Key != expected {
+		t.Errorf("Expected '%s', got '%s'", expected, cfg.API.Key)
+	}
+}
+
+func TestExpandEnvVars_VeryLongValues(t *testing.T) {
+	// Create a >1KB value
+	longValue := strings.Repeat("x", 2000)
+
+	cleanup := setupEnvTest(t, map[string]string{
+		"LONG_VAR": longValue,
+	})
+	defer cleanup()
+
+	cfg := &ConfigData{
+		API: APIConfig{
+			Key: "${LONG_VAR}",
+		},
+	}
+
+	ExpandEnvVars(cfg)
+
+	if len(cfg.API.Key) != 2000 {
+		t.Errorf("Expected length 2000, got %d", len(cfg.API.Key))
+	}
+	if cfg.API.Key != longValue {
+		t.Error("Long value was not preserved correctly")
+	}
+}
+
+func TestExpandEnvVars_VarNamesWithNumbers(t *testing.T) {
+	cleanup := setupEnvTest(t, map[string]string{
+		"VAR1":      "first",
+		"VAR2":      "second",
+		"API_KEY_2": "key-value",
+	})
+	defer cleanup()
+
+	cfg := &ConfigData{
+		API: APIConfig{
+			Key:     "$VAR1-$VAR2",
+			BaseURL: "${API_KEY_2}",
+		},
+	}
+
+	ExpandEnvVars(cfg)
+
+	if cfg.API.Key != "first-second" {
+		t.Errorf("API.Key: expected 'first-second', got '%s'", cfg.API.Key)
+	}
+	if cfg.API.BaseURL != "key-value" {
+		t.Errorf("API.BaseURL: expected 'key-value', got '%s'", cfg.API.BaseURL)
+	}
+}
+
+func TestExpandEnvVars_VarNamesWithUnderscores(t *testing.T) {
+	cleanup := setupEnvTest(t, map[string]string{
+		"MY_API_KEY":    "secret123",
+		"DB_CONNECTION": "postgres://localhost",
+	})
+	defer cleanup()
+
+	cfg := &ConfigData{
+		API: APIConfig{
+			Key:     "${MY_API_KEY}",
+			BaseURL: "$DB_CONNECTION",
+		},
+	}
+
+	ExpandEnvVars(cfg)
+
+	if cfg.API.Key != "secret123" {
+		t.Errorf("API.Key: expected 'secret123', got '%s'", cfg.API.Key)
+	}
+	if cfg.API.BaseURL != "postgres://localhost" {
+		t.Errorf("API.BaseURL: expected 'postgres://localhost', got '%s'", cfg.API.BaseURL)
+	}
+}
+
+// =============================================================================
+// Category 6: Integration (2 tests)
+// =============================================================================
+
+func TestExpandEnvVars_FullConfigExpansion(t *testing.T) {
+	cleanup := setupEnvTest(t, map[string]string{
+		"API_KEY":     "sk-production-key",
+		"BASE_URL":    "https://prod.api.com",
+		"MODEL":       "sonar-professional",
+		"TIMEOUT":     "60s",
+		"DOMAIN1":     "prod1.example.com",
+		"DOMAIN2":     "prod2.example.com",
+		"COUNTRY":     "US",
+		"IMG_DOMAIN1": "images1.cdn.com",
+		"IMG_DOMAIN2": "images2.cdn.com",
+		"FORMAT1":     "webp",
+	})
+	defer cleanup()
+
+	cfg := createTestConfig()
+
+	// Verify config has placeholders before expansion
+	if !strings.Contains(cfg.API.Key, "$") {
+		t.Error("Config should have $ placeholders before expansion")
+	}
+
+	ExpandEnvVars(cfg)
+
+	// Verify all sections expanded correctly
+	if cfg.API.Key != "sk-production-key" {
+		t.Errorf("API.Key not expanded correctly: %s", cfg.API.Key)
+	}
+	if cfg.API.BaseURL != "https://prod.api.com" {
+		t.Errorf("API.BaseURL not expanded correctly: %s", cfg.API.BaseURL)
+	}
+	if cfg.Defaults.Model != "sonar-professional" {
+		t.Errorf("Defaults.Model not expanded correctly: %s", cfg.Defaults.Model)
+	}
+	if cfg.Defaults.Timeout != "60s" {
+		t.Errorf("Defaults.Timeout not expanded correctly: %s", cfg.Defaults.Timeout)
+	}
+
+	// Verify arrays expanded correctly
+	expectedDomains := []string{"prod1.example.com", "prod2.example.com", "literal.com"}
+	if len(cfg.Search.Domains) != 3 {
+		t.Errorf("Expected 3 domains, got %d", len(cfg.Search.Domains))
+	}
+	for i, exp := range expectedDomains {
+		if cfg.Search.Domains[i] != exp {
+			t.Errorf("Domain[%d]: expected '%s', got '%s'", i, exp, cfg.Search.Domains[i])
+		}
+	}
+
+	if cfg.Search.LocationCountry != "US" {
+		t.Errorf("LocationCountry not expanded correctly: %s", cfg.Search.LocationCountry)
+	}
+
+	// Verify no $ symbols remain (except in literal.com)
+	if strings.Contains(cfg.API.Key, "$") ||
+		strings.Contains(cfg.API.BaseURL, "$") ||
+		strings.Contains(cfg.Defaults.Model, "$") ||
+		strings.Contains(cfg.Defaults.Timeout, "$") {
+		t.Error("Found unexpanded $ symbols in config")
+	}
+}
+
+func TestExpandEnvVars_EmptyConfigData(t *testing.T) {
+	// Test that ExpandEnvVars doesn't crash on empty/nil values
+	cfg := &ConfigData{}
+
+	// Should not panic
+	ExpandEnvVars(cfg)
+
+	// Verify config remains empty
+	if cfg.API.Key != "" {
+		t.Error("Empty config should remain empty")
+	}
+	if cfg.Defaults.Model != "" {
+		t.Error("Empty config should remain empty")
+	}
+	if len(cfg.Search.Domains) != 0 {
+		t.Error("Empty arrays should remain empty")
+	}
+	if len(cfg.Output.ImageDomains) != 0 {
+		t.Error("Empty arrays should remain empty")
+	}
+}

--- a/pkg/config/loader_test.go
+++ b/pkg/config/loader_test.go
@@ -260,3 +260,239 @@ profiles:
 		}
 	}
 }
+
+// =============================================================================
+// File System Edge Case Tests
+// =============================================================================
+
+func TestLoadFrom_FilePermissionDenied(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	// Create config file
+	configContent := "defaults:\n  model: test\n"
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	// Make file unreadable (chmod 000)
+	if err := os.Chmod(configPath, 0000); err != nil {
+		t.Fatalf("Failed to chmod file: %v", err)
+	}
+
+	// Restore permissions for cleanup
+	defer func() {
+		_ = os.Chmod(configPath, 0644)
+	}()
+
+	loader := NewLoader()
+	err := loader.LoadFrom(configPath)
+
+	// Should get permission error
+	if err == nil {
+		t.Error("Expected error for permission denied file")
+	}
+}
+
+func TestLoadFrom_CorruptedYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	// Create file with invalid structure (valid YAML syntax, but missing expected fields)
+	configContent := `
+this_is_valid_yaml: true
+but:
+  - not
+  - the
+  - expected
+  - structure
+`
+
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	loader := NewLoader()
+	err := loader.LoadFrom(configPath)
+
+	// May not error (depends on implementation), but should not crash
+	if err != nil {
+		t.Logf("Corrupted YAML returned error (expected): %v", err)
+	}
+
+	// Verify loader doesn't crash
+	data := loader.Data()
+	if data == nil {
+		t.Error("Data should not be nil even with corrupted YAML")
+	}
+}
+
+func TestLoadFrom_EmptyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	// Create empty file (0 bytes)
+	if err := os.WriteFile(configPath, []byte(""), 0644); err != nil {
+		t.Fatalf("Failed to create empty file: %v", err)
+	}
+
+	loader := NewLoader()
+	err := loader.LoadFrom(configPath)
+
+	// Empty file might be considered valid or invalid depending on implementation
+	if err != nil {
+		t.Logf("Empty file returned error: %v", err)
+	}
+
+	data := loader.Data()
+	if data == nil {
+		t.Error("Data should not be nil for empty file")
+	}
+}
+
+func TestLoadFrom_OnlyWhitespace(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	// Create file with only whitespace
+	configContent := "   \n\n   \n\t\t\n   "
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to create test file: %v", err)
+	}
+
+	loader := NewLoader()
+	err := loader.LoadFrom(configPath)
+
+	// Should handle whitespace gracefully
+	if err != nil {
+		t.Logf("Whitespace-only file returned error: %v", err)
+	}
+
+	data := loader.Data()
+	if data == nil {
+		t.Error("Data should not be nil for whitespace-only file")
+	}
+}
+
+func TestLoadFrom_VeryLargeFile(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping large file test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "large-config.yaml")
+
+	// Create a ~1MB config file with many profiles
+	var configContent string
+	configContent += "defaults:\n  model: test\n\nprofiles:\n"
+
+	for i := 0; i < 1000; i++ {
+		configContent += "  profile" + string(rune('0'+i%10)) + string(rune('0'+(i/10)%10)) + string(rune('0'+(i/100)%10)) + ":\n"
+		configContent += "    name: profile" + string(rune('0'+i%10)) + string(rune('0'+(i/10)%10)) + string(rune('0'+(i/100)%10)) + "\n"
+		configContent += "    defaults:\n"
+		configContent += "      model: model" + string(rune('0'+i%10)) + "\n"
+		configContent += "      temperature: 0.7\n"
+	}
+
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to create large file: %v", err)
+	}
+
+	loader := NewLoader()
+	err := loader.LoadFrom(configPath)
+
+	// Should handle large file without crashing
+	if err != nil {
+		t.Logf("Large file load error: %v", err)
+	} else {
+		data := loader.Data()
+		if data == nil {
+			t.Error("Data should not be nil for large file")
+		}
+		t.Logf("Successfully loaded large config file")
+	}
+}
+
+func TestLoad_SymbolicLinks(t *testing.T) {
+	tmpDir := t.TempDir()
+	realPath := filepath.Join(tmpDir, "real-config.yaml")
+	symlinkPath := filepath.Join(tmpDir, "config.yaml")
+
+	// Create real config file
+	configContent := "defaults:\n  model: symlink-test\n"
+	if err := os.WriteFile(realPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to create real file: %v", err)
+	}
+
+	// Create symlink
+	if err := os.Symlink(realPath, symlinkPath); err != nil {
+		t.Skipf("Cannot create symlink (may not be supported on this platform): %v", err)
+	}
+
+	loader := NewLoader()
+	err := loader.LoadFrom(symlinkPath)
+
+	// Should follow symlink and load successfully
+	if err != nil {
+		t.Errorf("Failed to load config through symlink: %v", err)
+	}
+
+	data := loader.Data()
+	if data.Defaults.Model != "symlink-test" {
+		t.Errorf("Expected model 'symlink-test', got '%s'", data.Defaults.Model)
+	}
+}
+
+func TestLoad_PathWithSpaces(t *testing.T) {
+	tmpDir := t.TempDir()
+	spacedDir := filepath.Join(tmpDir, "path with spaces")
+	if err := os.Mkdir(spacedDir, 0755); err != nil {
+		t.Fatalf("Failed to create directory with spaces: %v", err)
+	}
+
+	configPath := filepath.Join(spacedDir, "config.yaml")
+	configContent := "defaults:\n  model: spaced-path\n"
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to create config in spaced path: %v", err)
+	}
+
+	loader := NewLoader()
+	err := loader.LoadFrom(configPath)
+
+	// Should handle paths with spaces
+	if err != nil {
+		t.Errorf("Failed to load config from path with spaces: %v", err)
+	}
+
+	data := loader.Data()
+	if data.Defaults.Model != "spaced-path" {
+		t.Errorf("Expected model 'spaced-path', got '%s'", data.Defaults.Model)
+	}
+}
+
+func TestLoad_PathWithUnicode(t *testing.T) {
+	tmpDir := t.TempDir()
+	unicodeDir := filepath.Join(tmpDir, "路径-café")
+	if err := os.Mkdir(unicodeDir, 0755); err != nil {
+		t.Skipf("Cannot create directory with unicode (may not be supported): %v", err)
+	}
+
+	configPath := filepath.Join(unicodeDir, "config.yaml")
+	configContent := "defaults:\n  model: unicode-path\n"
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to create config in unicode path: %v", err)
+	}
+
+	loader := NewLoader()
+	err := loader.LoadFrom(configPath)
+
+	// Should handle unicode paths
+	if err != nil {
+		t.Errorf("Failed to load config from unicode path: %v", err)
+	}
+
+	data := loader.Data()
+	if data.Defaults.Model != "unicode-path" {
+		t.Errorf("Expected model 'unicode-path', got '%s'", data.Defaults.Model)
+	}
+}

--- a/pkg/config/merge_test.go
+++ b/pkg/config/merge_test.go
@@ -1,0 +1,701 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// createTestCommand creates a cobra.Command with common flags for testing.
+func createTestCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use: "test",
+		Run: func(cmd *cobra.Command, args []string) {},
+	}
+
+	// Add flags that match those in the actual application
+	cmd.Flags().String("model", "", "Model to use")
+	cmd.Flags().Float64("temperature", 0, "Temperature")
+	cmd.Flags().Int("max-tokens", 0, "Max tokens")
+	cmd.Flags().Int("top-k", 0, "Top K")
+	cmd.Flags().Float64("top-p", 0, "Top P")
+	cmd.Flags().Float64("frequency-penalty", 0, "Frequency penalty")
+	cmd.Flags().Float64("presence-penalty", 0, "Presence penalty")
+	cmd.Flags().Duration("timeout", 0, "Timeout")
+
+	// Search flags
+	cmd.Flags().StringSlice("search-domains", nil, "Search domains")
+	cmd.Flags().String("search-recency", "", "Search recency")
+	cmd.Flags().String("search-mode", "", "Search mode")
+	cmd.Flags().String("search-context-size", "", "Search context size")
+	cmd.Flags().Float64("location-lat", 0, "Location latitude")
+	cmd.Flags().Float64("location-lon", 0, "Location longitude")
+	cmd.Flags().String("location-country", "", "Location country")
+	cmd.Flags().String("search-after-date", "", "After date")
+	cmd.Flags().String("search-before-date", "", "Before date")
+	cmd.Flags().String("last-updated-after", "", "Last updated after")
+	cmd.Flags().String("last-updated-before", "", "Last updated before")
+
+	// Output flags
+	cmd.Flags().Bool("stream", false, "Stream output")
+	cmd.Flags().Bool("return-images", false, "Return images")
+	cmd.Flags().Bool("return-related", false, "Return related")
+	cmd.Flags().Bool("json", false, "JSON output")
+	cmd.Flags().StringSlice("image-domains", nil, "Image domains")
+	cmd.Flags().StringSlice("image-formats", nil, "Image formats")
+	cmd.Flags().String("response-format-json-schema", "", "JSON schema")
+	cmd.Flags().String("response-format-regex", "", "Regex format")
+	cmd.Flags().String("reasoning-effort", "", "Reasoning effort")
+
+	return cmd
+}
+
+// =============================================================================
+// Category 1: MergeWithFlags Tests (8 tests)
+// =============================================================================
+
+func TestMergeWithFlags_NoFlagsChanged(t *testing.T) {
+	// Config file values
+	cfg := &ConfigData{
+		Defaults: DefaultsConfig{
+			Model:       "config-model",
+			Temperature: 0.7,
+			MaxTokens:   1000,
+		},
+		Search: SearchConfig{
+			Recency: "week",
+			Mode:    "web",
+		},
+		Output: OutputConfig{
+			Stream: true,
+		},
+	}
+
+	cmd := createTestCommand()
+	merger := NewMerger(cfg)
+	if err := merger.BindFlags(cmd); err != nil {
+		t.Fatalf("Failed to bind flags: %v", err)
+	}
+
+	merged := merger.MergeWithFlags(cmd)
+
+	// Since no flags were changed, config values should be preserved
+	if merged.Defaults.Model != "config-model" {
+		t.Errorf("Model should be preserved from config, got '%s'", merged.Defaults.Model)
+	}
+	if merged.Defaults.Temperature != 0.7 {
+		t.Errorf("Temperature should be preserved from config, got %f", merged.Defaults.Temperature)
+	}
+	if merged.Defaults.MaxTokens != 1000 {
+		t.Errorf("MaxTokens should be preserved from config, got %d", merged.Defaults.MaxTokens)
+	}
+	if merged.Search.Recency != "week" {
+		t.Errorf("Recency should be preserved from config, got '%s'", merged.Search.Recency)
+	}
+	if !merged.Output.Stream {
+		t.Error("Stream should be preserved from config")
+	}
+}
+
+func TestMergeWithFlags_AllFlagsChanged(t *testing.T) {
+	// Config file values
+	cfg := &ConfigData{
+		Defaults: DefaultsConfig{
+			Model:       "config-model",
+			Temperature: 0.7,
+		},
+	}
+
+	cmd := createTestCommand()
+
+	// Set flags
+	_ = cmd.Flags().Set("model", "flag-model")
+	_ = cmd.Flags().Set("temperature", "0.9")
+
+	merger := NewMerger(cfg)
+	if err := merger.BindFlags(cmd); err != nil {
+		t.Fatalf("Failed to bind flags: %v", err)
+	}
+
+	merged := merger.MergeWithFlags(cmd)
+
+	// Flag values should override config
+	if merged.Defaults.Model != "flag-model" {
+		t.Errorf("Expected flag model 'flag-model', got '%s'", merged.Defaults.Model)
+	}
+	if merged.Defaults.Temperature != 0.9 {
+		t.Errorf("Expected flag temperature 0.9, got %f", merged.Defaults.Temperature)
+	}
+}
+
+func TestMergeWithFlags_PartialFlagsChanged(t *testing.T) {
+	cfg := &ConfigData{
+		Defaults: DefaultsConfig{
+			Model:       "config-model",
+			Temperature: 0.7,
+			MaxTokens:   1000,
+			TopK:        50,
+		},
+	}
+
+	cmd := createTestCommand()
+
+	// Only set some flags
+	_ = cmd.Flags().Set("model", "flag-model")
+	_ = cmd.Flags().Set("max-tokens", "2000")
+
+	merger := NewMerger(cfg)
+	if err := merger.BindFlags(cmd); err != nil {
+		t.Fatalf("Failed to bind flags: %v", err)
+	}
+
+	merged := merger.MergeWithFlags(cmd)
+
+	// Changed flags should override
+	if merged.Defaults.Model != "flag-model" {
+		t.Errorf("Model should be from flag, got '%s'", merged.Defaults.Model)
+	}
+	if merged.Defaults.MaxTokens != 2000 {
+		t.Errorf("MaxTokens should be from flag, got %d", merged.Defaults.MaxTokens)
+	}
+
+	// Unchanged flags should preserve config
+	if merged.Defaults.Temperature != 0.7 {
+		t.Errorf("Temperature should be from config, got %f", merged.Defaults.Temperature)
+	}
+	if merged.Defaults.TopK != 50 {
+		t.Errorf("TopK should be from config, got %d", merged.Defaults.TopK)
+	}
+}
+
+func TestMergeWithFlags_ExplicitZeroValues(t *testing.T) {
+	// This tests the critical Changed() pattern
+	cfg := &ConfigData{
+		Defaults: DefaultsConfig{
+			Temperature: 0.7,
+			TopK:        50,
+		},
+	}
+
+	cmd := createTestCommand()
+
+	// Explicitly set temperature to 0 (valid value)
+	_ = cmd.Flags().Set("temperature", "0")
+
+	merger := NewMerger(cfg)
+	if err := merger.BindFlags(cmd); err != nil {
+		t.Fatalf("Failed to bind flags: %v", err)
+	}
+
+	merged := merger.MergeWithFlags(cmd)
+
+	// Explicit zero should override config
+	if merged.Defaults.Temperature != 0 {
+		t.Errorf("Explicit zero temperature should override config, got %f", merged.Defaults.Temperature)
+	}
+
+	// Non-changed flag should preserve config
+	if merged.Defaults.TopK != 50 {
+		t.Errorf("TopK should be preserved from config, got %d", merged.Defaults.TopK)
+	}
+}
+
+func TestMergeWithFlags_BooleanHandling(t *testing.T) {
+	cfg := &ConfigData{
+		Output: OutputConfig{
+			Stream:        true,
+			ReturnImages:  false,
+			ReturnRelated: true,
+		},
+	}
+
+	cmd := createTestCommand()
+
+	// Explicitly set stream to false
+	_ = cmd.Flags().Set("stream", "false")
+	// Explicitly set return-images to true
+	_ = cmd.Flags().Set("return-images", "true")
+	// Don't touch return-related
+
+	merger := NewMerger(cfg)
+	if err := merger.BindFlags(cmd); err != nil {
+		t.Fatalf("Failed to bind flags: %v", err)
+	}
+
+	merged := merger.MergeWithFlags(cmd)
+
+	// Changed flags should override
+	if merged.Output.Stream {
+		t.Error("Stream should be false from flag")
+	}
+	if !merged.Output.ReturnImages {
+		t.Error("ReturnImages should be true from flag")
+	}
+
+	// Unchanged should preserve config
+	if !merged.Output.ReturnRelated {
+		t.Error("ReturnRelated should be preserved from config")
+	}
+}
+
+func TestMergeWithFlags_StringArrays(t *testing.T) {
+	cfg := &ConfigData{
+		Search: SearchConfig{
+			Domains: []string{"config1.com", "config2.com"},
+		},
+		Output: OutputConfig{
+			ImageFormats: []string{"png", "jpg"},
+		},
+	}
+
+	cmd := createTestCommand()
+
+	// Set search-domains flag
+	_ = cmd.Flags().Set("search-domains", "flag1.com,flag2.com,flag3.com")
+
+	merger := NewMerger(cfg)
+	if err := merger.BindFlags(cmd); err != nil {
+		t.Fatalf("Failed to bind flags: %v", err)
+	}
+
+	merged := merger.MergeWithFlags(cmd)
+
+	// Changed array should override
+	expectedDomains := []string{"flag1.com", "flag2.com", "flag3.com"}
+	if len(merged.Search.Domains) != len(expectedDomains) {
+		t.Fatalf("Expected %d domains, got %d", len(expectedDomains), len(merged.Search.Domains))
+	}
+	for i, exp := range expectedDomains {
+		if merged.Search.Domains[i] != exp {
+			t.Errorf("Domain[%d]: expected '%s', got '%s'", i, exp, merged.Search.Domains[i])
+		}
+	}
+
+	// Unchanged array should preserve config
+	if len(merged.Output.ImageFormats) != 2 {
+		t.Errorf("ImageFormats should be preserved from config")
+	}
+}
+
+func TestMergeWithFlags_DurationParsing(t *testing.T) {
+	cfg := &ConfigData{
+		Defaults: DefaultsConfig{
+			Timeout: "30s",
+		},
+	}
+
+	cmd := createTestCommand()
+
+	// Set timeout flag
+	_ = cmd.Flags().Set("timeout", "1m30s")
+
+	merger := NewMerger(cfg)
+	if err := merger.BindFlags(cmd); err != nil {
+		t.Fatalf("Failed to bind flags: %v", err)
+	}
+
+	merged := merger.MergeWithFlags(cmd)
+
+	// Timeout should be overridden and formatted correctly
+	expected := (1*time.Minute + 30*time.Second).String()
+	if merged.Defaults.Timeout != expected {
+		t.Errorf("Expected timeout '%s', got '%s'", expected, merged.Defaults.Timeout)
+	}
+}
+
+func TestMergeWithFlags_FloatBoundaries(t *testing.T) {
+	cfg := &ConfigData{
+		Defaults: DefaultsConfig{
+			Temperature: 0.5,
+		},
+	}
+
+	testCases := []struct {
+		name     string
+		value    string
+		expected float64
+	}{
+		{"zero", "0", 0.0},
+		{"exact max", "2.0", 2.0},
+		{"small value", "0.1", 0.1},
+		{"mid value", "1.5", 1.5},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := createTestCommand()
+			_ = cmd.Flags().Set("temperature", tc.value)
+
+			merger := NewMerger(cfg)
+			if err := merger.BindFlags(cmd); err != nil {
+				t.Fatalf("Failed to bind flags: %v", err)
+			}
+
+			merged := merger.MergeWithFlags(cmd)
+
+			if merged.Defaults.Temperature != tc.expected {
+				t.Errorf("Expected temperature %f, got %f", tc.expected, merged.Defaults.Temperature)
+			}
+		})
+	}
+}
+
+// =============================================================================
+// Category 2: Precedence Chain Tests (5 tests)
+// =============================================================================
+
+func TestPrecedence_CLIOverridesConfig(t *testing.T) {
+	cfg := &ConfigData{
+		Defaults: DefaultsConfig{
+			Model: "config-model",
+		},
+	}
+
+	cmd := createTestCommand()
+	_ = cmd.Flags().Set("model", "cli-model")
+
+	merger := NewMerger(cfg)
+	if err := merger.BindFlags(cmd); err != nil {
+		t.Fatalf("Failed to bind flags: %v", err)
+	}
+
+	merged := merger.MergeWithFlags(cmd)
+
+	if merged.Defaults.Model != "cli-model" {
+		t.Errorf("CLI flag should override config, got '%s'", merged.Defaults.Model)
+	}
+}
+
+func TestPrecedence_ConfigOverridesDefaults(t *testing.T) {
+	// Config with values set
+	cfg := &ConfigData{
+		Defaults: DefaultsConfig{
+			Model:       "config-model",
+			Temperature: 0.8,
+			MaxTokens:   2000,
+		},
+	}
+
+	cmd := createTestCommand()
+	// No flags set
+
+	merger := NewMerger(cfg)
+	if err := merger.BindFlags(cmd); err != nil {
+		t.Fatalf("Failed to bind flags: %v", err)
+	}
+
+	merged := merger.MergeWithFlags(cmd)
+
+	// Config values should be used (they override zero defaults)
+	if merged.Defaults.Model != "config-model" {
+		t.Errorf("Config should override defaults, got '%s'", merged.Defaults.Model)
+	}
+	if merged.Defaults.Temperature != 0.8 {
+		t.Errorf("Config should override defaults, got %f", merged.Defaults.Temperature)
+	}
+	if merged.Defaults.MaxTokens != 2000 {
+		t.Errorf("Config should override defaults, got %d", merged.Defaults.MaxTokens)
+	}
+}
+
+func TestPrecedence_CLIOverridesEnvVar(t *testing.T) {
+	// Set up environment variable
+	cleanup := setupEnvTest(t, map[string]string{
+		"TEST_MODEL": "env-model",
+	})
+	defer cleanup()
+
+	cfg := &ConfigData{
+		Defaults: DefaultsConfig{
+			Model: "${TEST_MODEL}",
+		},
+	}
+
+	// Expand env vars first
+	ExpandEnvVars(cfg)
+
+	// Verify env var was expanded
+	if cfg.Defaults.Model != "env-model" {
+		t.Fatalf("Env var should be expanded, got '%s'", cfg.Defaults.Model)
+	}
+
+	// Now set CLI flag
+	cmd := createTestCommand()
+	_ = cmd.Flags().Set("model", "cli-model")
+
+	merger := NewMerger(cfg)
+	if err := merger.BindFlags(cmd); err != nil {
+		t.Fatalf("Failed to bind flags: %v", err)
+	}
+
+	merged := merger.MergeWithFlags(cmd)
+
+	// CLI should override env var (which was in config)
+	if merged.Defaults.Model != "cli-model" {
+		t.Errorf("CLI flag should override env var, got '%s'", merged.Defaults.Model)
+	}
+}
+
+func TestPrecedence_EnvVarOverridesConfig(t *testing.T) {
+	cleanup := setupEnvTest(t, map[string]string{
+		"ENV_MODEL": "env-value",
+	})
+	defer cleanup()
+
+	// Config with env var reference takes precedence over literal value
+	cfg := &ConfigData{
+		Defaults: DefaultsConfig{
+			Model: "$ENV_MODEL",
+		},
+	}
+
+	ExpandEnvVars(cfg)
+
+	if cfg.Defaults.Model != "env-value" {
+		t.Errorf("Env var should expand to 'env-value', got '%s'", cfg.Defaults.Model)
+	}
+}
+
+func TestPrecedence_FullChainIntegration(t *testing.T) {
+	// Set up all three sources
+	cleanup := setupEnvTest(t, map[string]string{
+		"ENV_TEMP": "0.6",
+	})
+	defer cleanup()
+
+	// Config file with mix of literal and env var
+	cfg := &ConfigData{
+		Defaults: DefaultsConfig{
+			Model:       "config-model",        // Literal in config
+			Temperature: 0.5,                   // Will be overridden by CLI
+			MaxTokens:   1000,                  // Will stay from config
+			TopK:        50,                    // Will be overridden by CLI
+		},
+		Search: SearchConfig{
+			Recency: "week", // Will stay from config
+		},
+	}
+
+	// Expand env vars (though none in this test)
+	ExpandEnvVars(cfg)
+
+	// Set some CLI flags
+	cmd := createTestCommand()
+	_ = cmd.Flags().Set("temperature", "0.9")  // CLI override
+	_ = cmd.Flags().Set("top-k", "100")        // CLI override
+
+	merger := NewMerger(cfg)
+	if err := merger.BindFlags(cmd); err != nil {
+		t.Fatalf("Failed to bind flags: %v", err)
+	}
+
+	merged := merger.MergeWithFlags(cmd)
+
+	// Verify precedence: CLI > env var > config > defaults
+	if merged.Defaults.Temperature != 0.9 {
+		t.Errorf("CLI should win for temperature, got %f", merged.Defaults.Temperature)
+	}
+	if merged.Defaults.TopK != 100 {
+		t.Errorf("CLI should win for top-k, got %d", merged.Defaults.TopK)
+	}
+	if merged.Defaults.Model != "config-model" {
+		t.Errorf("Config should be preserved for model, got '%s'", merged.Defaults.Model)
+	}
+	if merged.Defaults.MaxTokens != 1000 {
+		t.Errorf("Config should be preserved for max-tokens, got %d", merged.Defaults.MaxTokens)
+	}
+	if merged.Search.Recency != "week" {
+		t.Errorf("Config should be preserved for recency, got '%s'", merged.Search.Recency)
+	}
+}
+
+// =============================================================================
+// Category 3: LoadAndMergeConfig Integration (6 tests)
+// =============================================================================
+
+func TestLoadAndMergeConfig_CompleteWorkflow(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `
+defaults:
+  model: workflow-model
+  temperature: 0.8
+  max_tokens: 1500
+
+search:
+  recency: month
+  mode: academic
+
+output:
+  stream: true
+  return_images: false
+`
+
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+
+	cmd := createTestCommand()
+	// Don't set any flags
+
+	cfg, err := LoadAndMergeConfig(cmd, configPath)
+	if err != nil {
+		t.Fatalf("LoadAndMergeConfig failed: %v", err)
+	}
+
+	// Verify loaded values
+	if cfg.Defaults.Model != "workflow-model" {
+		t.Errorf("Expected model 'workflow-model', got '%s'", cfg.Defaults.Model)
+	}
+	if cfg.Defaults.Temperature != 0.8 {
+		t.Errorf("Expected temperature 0.8, got %f", cfg.Defaults.Temperature)
+	}
+	if cfg.Search.Recency != "month" {
+		t.Errorf("Expected recency 'month', got '%s'", cfg.Search.Recency)
+	}
+}
+
+func TestLoadAndMergeConfig_WithEnvVars(t *testing.T) {
+	cleanup := setupEnvTest(t, map[string]string{
+		"TEST_API_KEY": "sk-env-key-123",
+		"TEST_MODEL":   "env-model",
+	})
+	defer cleanup()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `
+api:
+  key: $TEST_API_KEY
+
+defaults:
+  model: ${TEST_MODEL}
+  temperature: 0.7
+`
+
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+
+	cmd := createTestCommand()
+
+	cfg, err := LoadAndMergeConfig(cmd, configPath)
+	if err != nil {
+		t.Fatalf("LoadAndMergeConfig failed: %v", err)
+	}
+
+	// Verify env vars were expanded
+	if cfg.API.Key != "sk-env-key-123" {
+		t.Errorf("API key should be expanded from env, got '%s'", cfg.API.Key)
+	}
+	if cfg.Defaults.Model != "env-model" {
+		t.Errorf("Model should be expanded from env, got '%s'", cfg.Defaults.Model)
+	}
+}
+
+func TestLoadAndMergeConfig_NoConfigFile(t *testing.T) {
+	cmd := createTestCommand()
+
+	// Pass empty path
+	cfg, err := LoadAndMergeConfig(cmd, "")
+	if err != nil {
+		t.Fatalf("LoadAndMergeConfig should not fail without config file: %v", err)
+	}
+
+	// Should return empty config
+	if cfg == nil {
+		t.Fatal("Config should not be nil")
+	}
+}
+
+func TestLoadAndMergeConfig_CLIOverridesAll(t *testing.T) {
+	cleanup := setupEnvTest(t, map[string]string{
+		"ENV_MODEL": "env-model",
+	})
+	defer cleanup()
+
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `
+defaults:
+  model: $ENV_MODEL
+  temperature: 0.7
+`
+
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+
+	cmd := createTestCommand()
+	// Set CLI flags
+	_ = cmd.Flags().Set("model", "cli-model")
+	_ = cmd.Flags().Set("temperature", "0.9")
+
+	cfg, err := LoadAndMergeConfig(cmd, configPath)
+	if err != nil {
+		t.Fatalf("LoadAndMergeConfig failed: %v", err)
+	}
+
+	// CLI should override everything
+	if cfg.Defaults.Model != "cli-model" {
+		t.Errorf("CLI should override config and env, got '%s'", cfg.Defaults.Model)
+	}
+	if cfg.Defaults.Temperature != 0.9 {
+		t.Errorf("CLI should override config, got %f", cfg.Defaults.Temperature)
+	}
+}
+
+func TestLoadAndMergeConfig_WithActiveProfile(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `
+defaults:
+  model: base-model
+  temperature: 0.5
+
+active_profile: production
+
+profiles:
+  production:
+    name: production
+    defaults:
+      model: prod-model
+      temperature: 0.8
+`
+
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config: %v", err)
+	}
+
+	cmd := createTestCommand()
+
+	cfg, err := LoadAndMergeConfig(cmd, configPath)
+	if err != nil {
+		t.Fatalf("LoadAndMergeConfig failed: %v", err)
+	}
+
+	// Profile values should be merged
+	if cfg.Defaults.Model != "prod-model" {
+		t.Errorf("Profile should override base config, got '%s'", cfg.Defaults.Model)
+	}
+	if cfg.Defaults.Temperature != 0.8 {
+		t.Errorf("Profile should override base config, got %f", cfg.Defaults.Temperature)
+	}
+}
+
+func TestLoadAndMergeConfig_InvalidConfigPath(t *testing.T) {
+	cmd := createTestCommand()
+
+	// Try to load non-existent file
+	_, err := LoadAndMergeConfig(cmd, "/nonexistent/path/config.yaml")
+	if err == nil {
+		t.Error("Expected error for invalid config path")
+	}
+}


### PR DESCRIPTION
Add 67 new test functions covering critical edge cases and integration scenarios:

- envexpand_test.go (22 tests): environment variable interpolation with various
  syntax forms ($VAR, ${VAR}), special characters, unicode, arrays, and edge cases
- merge_test.go (19 tests): CLI flag merging, precedence chains, and full
  LoadAndMergeConfig integration workflows
- validator_test.go (+12 tests): boundary value testing for temperature,
  coordinates, date formats, and profile names
- loader_test.go (+8 tests): file system edge cases including permissions,
  corrupted YAML, symlinks, and unicode paths
- profiles_test.go (+6 tests): profile merging with env vars, arrays, booleans,
  and chained expansion

Coverage improvements:
- ExpandEnvVars: 0% → 100%
- expandString: 0% → 100%
- LoadAndMergeConfig: 0% → 94.1%
- MergeWithFlags: 0% → 65.5%
- Overall package: 66.0% → 75.5%

All tests passing with no flaky behavior detected.