### PR TITLE
fix(linter): resolve gosec and fmt.Sprintf linter warnings

### DIFF
--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -334,7 +334,7 @@ func getBashInstallTarget(homeDir string) (*shellInstallTarget, error) {
 
 	targetPath := filepath.Join(brewPrefix, "etc", "bash_completion.d", "pplx")
 	// Check if Homebrew bash_completion.d directory exists
-	if _, err := os.Stat(filepath.Dir(targetPath)); os.IsNotExist(err) {
+	if _, err := os.Stat(filepath.Dir(targetPath)); os.IsNotExist(err) { //nolint:gosec // G703: path is constructed from trusted env/home dir sources
 		// Attempt 2: User directory fallback (Linux-style path)
 		targetPath = filepath.Join(homeDir, ".bash_completion.d", "pplx")
 		if err := os.MkdirAll(filepath.Dir(targetPath), dirPerms); err != nil { // #nosec G301

--- a/pkg/config/annotate.go
+++ b/pkg/config/annotate.go
@@ -296,7 +296,7 @@ func GenerateAnnotatedConfig(cfg *ConfigData, opts AnnotationOptions) (string, e
 		output.WriteString("\nprofiles:\n")
 
 		for name, profile := range cfg.Profiles {
-			output.WriteString(fmt.Sprintf("  %s:\n", name))
+			fmt.Fprintf(&output, "  %s:\n", name)
 			profileYAML, err := yaml.Marshal(profile)
 			if err != nil {
 				return "", fmt.Errorf("failed to marshal profile %s: %w", name, err)
@@ -313,7 +313,7 @@ func GenerateAnnotatedConfig(cfg *ConfigData, opts AnnotationOptions) (string, e
 	// Add active profile
 	if cfg.ActiveProfile != "" {
 		output.WriteString("\n# Currently active profile\n")
-		output.WriteString(fmt.Sprintf("active_profile: %s\n", cfg.ActiveProfile))
+		fmt.Fprintf(&output, "active_profile: %s\n", cfg.ActiveProfile)
 	}
 
 	// Add example profiles if requested

--- a/pkg/mcp/server.go
+++ b/pkg/mcp/server.go
@@ -21,7 +21,7 @@ type MCPServer struct {
 
 // ServerConfig contains configuration for the MCP server.
 type ServerConfig struct {
-	APIKey  string
+	APIKey  string //nolint:gosec // G117: field name is intentional for API key config
 	Version string
 	Name    string
 }


### PR DESCRIPTION
- cmd/completion.go: add nolint gosec G703 for trusted path construction
- pkg/config/annotate.go: use fmt.Fprintf instead of WriteString+Sprintf
- pkg/mcp/server.go: add nolint gosec G117 for APIKey field name

Refs #118