### PR TITLE
feat(cmd): add --config flag to chat and query commands (Closes #127)

### DIFF
--- a/README.md
+++ b/README.md
@@ -904,6 +904,10 @@ The MCP server returns JSON with the following structure:
 3. **Configuration issues**: Check JSON syntax in MCP config files
 4. **API errors**: Verify your API key is valid and has sufficient credits
 
+### Common Errors
+
+- **`API error: failed to send completion request: unauthorized: check your API key`**: This error can occur not only with an invalid API key but also when your Perplexity account has **0 credits remaining**. Make sure your account has sufficient credits at [perplexity.ai](https://www.perplexity.ai/).
+
 ### Advanced Configuration Examples
 
 #### High-quality research with academic sources

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -277,6 +277,7 @@ func init() {
 	addFormatFlags(chatCmd)
 	addDateFlags(chatCmd)
 	addResearchFlags(chatCmd)
+	chatCmd.PersistentFlags().StringVar(&configFilePath, "config", "", "Path to config file")
 	registerFlagCompletions(chatCmd)
 
 	rootCmd.AddCommand(queryCmd)
@@ -290,6 +291,7 @@ func init() {
 	addDateFlags(queryCmd)
 	addResearchFlags(queryCmd)
 	addOutputFlags(queryCmd)
+	queryCmd.PersistentFlags().StringVar(&configFilePath, "config", "", "Path to config file")
 	registerFlagCompletions(queryCmd)
 
 	rootCmd.AddCommand(mcpStdioCmd)


### PR DESCRIPTION
- Register --config persistent flag on chatCmd and queryCmd in root.go
- Document common API unauthorized error for 0-credit accounts in README